### PR TITLE
Refactor img-downloader and add coin ids support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,6 +3196,7 @@ dependencies = [
  "gem_evm",
  "primitives",
  "reqwest",
+ "serde",
  "settings",
  "tokio",
 ]

--- a/bin/img-downloader/Cargo.toml
+++ b/bin/img-downloader/Cargo.toml
@@ -5,6 +5,7 @@ edition = { workspace = true }
 
 [dependencies]
 tokio = { workspace = true }
+serde = { workspace = true }
 reqwest = { workspace = true, features = ["stream"] }
 futures-util = { workspace = true }
 clap = { version = "4.5.1", features = ["derive"] }

--- a/bin/img-downloader/src/cli_args.rs
+++ b/bin/img-downloader/src/cli_args.rs
@@ -1,0 +1,37 @@
+use clap::{arg, Parser};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Path to save images
+    #[arg(short, long)]
+    pub folder: String,
+
+    /// Top tokens on coingecko to download
+    #[arg(short, long, default_value_t = 50)]
+    pub count: u32,
+
+    /// Starting page
+    #[arg(short, long, default_value_t = 1)]
+    pub page: u32,
+
+    /// Page size
+    #[arg(long, default_value_t = 50)]
+    pub page_size: u32,
+
+    /// ID of the coin, if this is set, it will only download the image for the coin
+    #[arg(long, default_value = "")]
+    pub coin_id: String,
+
+    /// Coin IDs to download, separated by comma
+    #[arg(long, default_value = "")]
+    pub coin_ids: String,
+
+    /// Coin IDs from URL to download
+    #[arg(long, default_value = "")]
+    pub coin_ids_url: String,
+
+    /// Verbose mode
+    #[arg(short, long, default_value_t = false)]
+    pub verbose: bool,
+}

--- a/bin/img-downloader/src/cli_args.rs
+++ b/bin/img-downloader/src/cli_args.rs
@@ -11,11 +11,11 @@ pub struct Args {
     #[arg(short, long, default_value_t = 50)]
     pub count: u32,
 
-    /// Starting page
+    /// Starting page for coingecko api
     #[arg(short, long, default_value_t = 1)]
     pub page: u32,
 
-    /// Page size
+    /// Page size for coingecko api
     #[arg(long, default_value_t = 50)]
     pub page_size: u32,
 
@@ -23,11 +23,11 @@ pub struct Args {
     #[arg(long, default_value = "")]
     pub coin_id: String,
 
-    /// Coin IDs to download, separated by comma
+    /// Coin IDs separated by comma to download, exclusive with coin_ids_url
     #[arg(long, default_value = "")]
     pub coin_ids: String,
 
-    /// Coin IDs from URL to download
+    /// Coin IDs from URL to download, exclusive with coin_ids_url
     #[arg(long, default_value = "")]
     pub coin_ids_url: String,
 

--- a/bin/img-downloader/src/cli_model.rs
+++ b/bin/img-downloader/src/cli_model.rs
@@ -1,0 +1,7 @@
+use primitives::PriceFull;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct Response {
+    pub results: Vec<PriceFull>,
+}

--- a/bin/img-downloader/src/main.rs
+++ b/bin/img-downloader/src/main.rs
@@ -1,42 +1,20 @@
-use clap::{arg, Parser};
-use coingecko::get_chain_for_coingecko_id;
+mod cli_args;
+mod cli_model;
+
+use clap::Parser;
+use cli_args::Args;
+
+use coingecko::get_chain_for_coingecko_platform_id;
 use coingecko::{CoinGeckoClient, CoinInfo};
-use futures_util::StreamExt;
 use gem_evm::address::EthereumAddress;
 use settings::Settings;
+
+use futures_util::StreamExt;
 use std::{
     error::Error, fs, io::Write, path::Path, str::FromStr, thread::sleep, time::Duration, vec,
 };
 
 /// Assets image downloader from coingecko
-#[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
-struct Args {
-    /// Path to save images
-    #[arg(short, long)]
-    folder: String,
-
-    /// Top number of tokens to download
-    #[arg(short, long, default_value_t = 50)]
-    count: u32,
-
-    /// Starting page
-    #[arg(short, long, default_value_t = 1)]
-    page: u32,
-
-    /// Page size
-    #[arg(long, default_value_t = 50)]
-    page_size: u32,
-
-    /// ID of the coin
-    #[arg(long, default_value = "")]
-    coin_id: String,
-
-    /// Verbose mode
-    #[arg(short, long, default_value_t = false)]
-    verbose: bool,
-}
-
 struct Downloader {
     args: Args,
     client: CoinGeckoClient,
@@ -63,14 +41,49 @@ impl Downloader {
             fs::create_dir_all(folder)?;
         }
 
-        let coin_id = self.args.coin_id.clone();
-        if !coin_id.is_empty() {
-            let market = self.client.get_coin_markets_id(coin_id.as_str()).await?;
-            self.handle_coin(&market.clone().id, folder).await?;
-
-            return Ok(());
+        if !self.args.coin_id.clone().is_empty() {
+            return self
+                .handle_coin_id(self.args.coin_id.as_str(), folder)
+                .await;
         }
 
+        if !self.args.coin_ids.clone().is_empty() {
+            return self
+                .handle_coin_ids(self.args.coin_ids.clone(), folder)
+                .await;
+        }
+
+        if !self.args.coin_ids_url.is_empty() {
+            return self.handle_coin_url(&self.args.coin_ids_url, folder).await;
+        }
+
+        self.handle_coingecto_top(folder).await
+    }
+
+    async fn handle_coin_id(&self, coin_id: &str, folder: &Path) -> Result<(), Box<dyn Error>> {
+        let market = self.client.get_coin_markets_id(coin_id).await?;
+        self.handle_coin(&market.clone().id, folder).await?;
+        Ok(())
+    }
+
+    async fn handle_coin_ids(&self, coin_ids: String, folder: &Path) -> Result<(), Box<dyn Error>> {
+        let ids: Vec<String> = coin_ids.split(',').map(|x| x.trim().to_string()).collect();
+        for coin_id in ids {
+            let market = self.client.get_coin_markets_id(coin_id.as_str()).await?;
+            self.handle_coin(&market.clone().id, folder).await?;
+        }
+        Ok(())
+    }
+
+    async fn handle_coin_url(&self, url: &str, folder: &Path) -> Result<(), Box<dyn Error>> {
+        let response: cli_model::Response = reqwest::get(url).await?.json().await?;
+        for price in response.results {
+            self.handle_coin_id(&price.coin_id, folder).await?;
+        }
+        Ok(())
+    }
+
+    async fn handle_coingecto_top(&self, folder: &Path) -> Result<(), Box<dyn Error>> {
         let mut page = self.args.page;
         let total_pages = self.args.count.div_ceil(self.args.page_size);
         while page <= total_pages {
@@ -94,7 +107,7 @@ impl Downloader {
         }
 
         for (platform, address) in coin_info.platforms.iter().filter(|(k, _)| !k.is_empty()) {
-            let chain = get_chain_for_coingecko_id(platform);
+            let chain = get_chain_for_coingecko_platform_id(platform);
             if chain.is_none() || address.is_empty() {
                 if self.args.verbose {
                     println!("<== {} not supported, skip", platform);
@@ -150,7 +163,7 @@ impl Downloader {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let args = Args::parse();
+    let args = cli_args::Args::parse();
     let api_key = Settings::new().unwrap().coingecko.key.secret;
     let downloader = Downloader::new(args, api_key);
 

--- a/bin/img-downloader/src/main.rs
+++ b/bin/img-downloader/src/main.rs
@@ -1,14 +1,13 @@
 mod cli_args;
-mod cli_model;
-
-use clap::Parser;
 use cli_args::Args;
+mod cli_model;
 
 use coingecko::get_chain_for_coingecko_platform_id;
 use coingecko::{CoinGeckoClient, CoinInfo};
 use gem_evm::address::EthereumAddress;
 use settings::Settings;
 
+use clap::Parser;
 use futures_util::StreamExt;
 use std::{
     error::Error, fs, io::Write, path::Path, str::FromStr, thread::sleep, time::Duration, vec,
@@ -62,7 +61,7 @@ impl Downloader {
 
     async fn handle_coin_id(&self, coin_id: &str, folder: &Path) -> Result<(), Box<dyn Error>> {
         let market = self.client.get_coin_markets_id(coin_id).await?;
-        self.handle_coin(&market.clone().id, folder).await?;
+        self.handle_coin(&market.id, folder).await?;
         Ok(())
     }
 
@@ -70,7 +69,7 @@ impl Downloader {
         let ids: Vec<String> = coin_ids.split(',').map(|x| x.trim().to_string()).collect();
         for coin_id in ids {
             let market = self.client.get_coin_markets_id(coin_id.as_str()).await?;
-            self.handle_coin(&market.clone().id, folder).await?;
+            self.handle_coin(&market.id, folder).await?;
         }
         Ok(())
     }

--- a/bin/img-downloader/src/main.rs
+++ b/bin/img-downloader/src/main.rs
@@ -41,13 +41,13 @@ impl Downloader {
             fs::create_dir_all(folder)?;
         }
 
-        if !self.args.coin_id.clone().is_empty() {
+        if !self.args.coin_id.is_empty() {
             return self
                 .handle_coin_id(self.args.coin_id.as_str(), folder)
                 .await;
         }
 
-        if !self.args.coin_ids.clone().is_empty() {
+        if !self.args.coin_ids.is_empty() {
             return self
                 .handle_coin_ids(self.args.coin_ids.clone(), folder)
                 .await;


### PR DESCRIPTION
- Move 4 different modes to separate methods
- Split files 

```bash
# pass coin ids separate by comma
cargo run --package img-downloader -- --folder <path/to/save> --coin-ids savvy-defi,decentral-games-old --verbose
```

```bash
# pass price url
cargo run --package img-downloader -- --folder <path/to/save> --coin-ids-url http://localhost:8000/v1/prices/list --verbose
```