### PR TITLE
Remove `n` from Aftermath response

### DIFF
--- a/crates/swap_aftermath/src/provider.rs
+++ b/crates/swap_aftermath/src/provider.rs
@@ -52,15 +52,15 @@ impl SwapProvider for AftermathProvider {
             let tx_response: String = self.provider.request_json(AftermathApi::Tx(tx)).await?;
             data = Some(SwapQuoteData {
                 to: "".into(), // tx is programmable tx, there is no single to address
-                value: response.coin_out.amount.clone(),
+                value: response.coin_out.amount.replace('n', " "),
                 data: tx_response,
             });
         }
 
         Ok(SwapQuote {
             chain_type: request.from_asset.chain.chain_type(),
-            from_amount: response.coin_in.amount,
-            to_amount: response.coin_out.amount,
+            from_amount: response.coin_in.amount.replace('n', ""),
+            to_amount: response.coin_out.amount.replace('n', " "),
             fee_percent: self.fee_percentage,
             provider: self.provider(),
             data,


### PR DESCRIPTION
```json
      "spotPrice": 0.0022299524166955447,
      "coinIn": {
        "type": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
        "amount": "1000000n",
        "tradeFee": "0n"
      },
      "coinOut": {
        "type": "0xe4239cd951f6c53d9c41e25270d80d31f925ad1655e5ba5b543843d4a66975ee::SUIP::SUIP",
        "amount": "448440062n",
        "tradeFee": "0n"
      },
```