### PR TITLE
Use Aftermath trade-base64-v2 endpoint

### DIFF
--- a/crates/swap_aftermath/src/api.rs
+++ b/crates/swap_aftermath/src/api.rs
@@ -23,7 +23,7 @@ impl Target for AftermathApi {
     fn path(&self) -> &'static str {
         match self {
             AftermathApi::Quote(_) => "/router/trade-route",
-            AftermathApi::Tx(_) => "/router/transactions/trade-base64",
+            AftermathApi::Tx(_) => "/router/transactions/trade-base64-v2",
         }
     }
 

--- a/crates/swap_aftermath/src/models.rs
+++ b/crates/swap_aftermath/src/models.rs
@@ -6,7 +6,8 @@ pub struct TradeQuote {
     pub coin_in_type: String,
     pub coin_out_type: String,
     pub coin_in_amount: String,
-    pub external_fee: ExternalFee,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_fee: Option<ExternalFee>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/swap_aftermath/src/provider.rs
+++ b/crates/swap_aftermath/src/provider.rs
@@ -84,14 +84,20 @@ impl TradeQuote {
         fee_address: String,
         fee_percentage: f32,
     ) -> Self {
+        let external_fee = if fee_address.is_empty() {
+            None
+        } else {
+            Some(ExternalFee {
+                recipient: fee_address,
+                fee_percentage,
+            })
+        };
+
         TradeQuote {
             coin_in_type: get_coin_type(&request.from_asset),
             coin_out_type: get_coin_type(&request.to_asset),
             coin_in_amount: request.amount.clone(),
-            external_fee: ExternalFee {
-                recipient: fee_address.clone(),
-                fee_percentage,
-            },
+            external_fee,
         }
     }
 }


### PR DESCRIPTION
To fix errors like "TypeError: Invalid enum variant undefined"