### PR TITLE
Return 1inch error for swap data

### DIFF
--- a/crates/swap_oneinch/src/model.rs
+++ b/crates/swap_oneinch/src/model.rs
@@ -26,6 +26,21 @@ pub struct SwapResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ErrorResponse {
+    pub error: String,
+    pub status_code: u64,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SwapResponse {
+    Success(SwapResult),
+    Error(ErrorResponse),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SwapResultTransaction {
     pub to: String,
     pub value: String,


### PR DESCRIPTION
Example:
```json
{
  "error": "Bad Request (400): Not enough allowance. Amount: 100000000000000000. Allowance: 0. Spender: 0x6e2b76966cbd9cf4cc2fa0d76d24d5241e0abc2f"
}
```