### PR TITLE
Return `spender` for 1inch quote API

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
-  unit_test:
+  docker_build:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6965,6 +6965,7 @@ name = "swap_oneinch"
 version = "1.0.0"
 dependencies = [
  "async-trait",
+ "futures",
  "gem_evm",
  "primitives",
  "reqwest 0.12.4",

--- a/crates/primitives/src/chain_evm.rs
+++ b/crates/primitives/src/chain_evm.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use crate::Chain;
 use serde::{Deserialize, Serialize};
 use strum::{EnumIter, IntoEnumIterator};
@@ -69,7 +71,7 @@ impl EVMChain {
         }
     }
 
-    pub fn oneinch(&self) -> &'static str {
+    pub fn oneinch(&self) -> Vec<&'static str> {
         match self {
             Self::Ethereum
             | Self::SmartChain
@@ -79,9 +81,11 @@ impl EVMChain {
             | Self::Fantom
             | Self::Gnosis
             | Self::Optimism
-            | Self::Base => "0x1111111254EEB25477B68fb85Ed929f73A960582",
-            Self::ZkSync => "0x6e2B76966cbD9cF4cC2Fa0D76d24d5241E0ABC2F",
-            Self::Manta | Self::Blast | Self::Linea | Self::Mantle | Self::OpBNB | Self::Celo => "", // 1inch does not support Manta
+            | Self::Base => vec!["0x1111111254EEB25477B68fb85Ed929f73A960582"],
+            Self::ZkSync => vec!["0x6e2B76966cbD9cF4cC2Fa0D76d24d5241E0ABC2F"],
+            Self::Manta | Self::Blast | Self::Linea | Self::Mantle | Self::OpBNB | Self::Celo => {
+                vec![]
+            } // 1inch does not support Manta
         }
     }
 

--- a/crates/primitives/src/chain_evm.rs
+++ b/crates/primitives/src/chain_evm.rs
@@ -69,6 +69,22 @@ impl EVMChain {
         }
     }
 
+    pub fn oneinch(&self) -> &'static str {
+        match self {
+            Self::Ethereum
+            | Self::SmartChain
+            | Self::Polygon
+            | Self::Arbitrum
+            | Self::AvalancheC
+            | Self::Fantom
+            | Self::Gnosis
+            | Self::Optimism
+            | Self::Base => "0x1111111254EEB25477B68fb85Ed929f73A960582",
+            Self::ZkSync => "0x6e2B76966cbD9cF4cC2Fa0D76d24d5241E0ABC2F",
+            Self::Manta | Self::Blast | Self::Linea | Self::Mantle | Self::OpBNB | Self::Celo => "", // 1inch does not support Manta
+        }
+    }
+
     pub fn to_chain(&self) -> Chain {
         match self {
             Self::Ethereum => Chain::Ethereum,

--- a/crates/primitives/src/swap.rs
+++ b/crates/primitives/src/swap.rs
@@ -51,6 +51,13 @@ pub struct SwapQuoteResult {
     pub quote: SwapQuote,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[typeshare(swift = "Codable, Equatable, Hashable")]
+#[serde(rename_all = "camelCase")]
+pub struct SwapApprovalData {
+    pub spender: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[typeshare(swift = "Codable, Equatable, Hashable")]
 #[serde(rename_all = "camelCase")]
@@ -61,6 +68,8 @@ pub struct SwapQuote {
     pub fee_percent: f32,
     pub provider: SwapProvider,
     pub data: Option<SwapQuoteData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval: Option<SwapApprovalData>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/swap_aftermath/src/provider.rs
+++ b/crates/swap_aftermath/src/provider.rs
@@ -67,6 +67,7 @@ impl SwapProvider for AftermathProvider {
             fee_percent: self.fee_percentage,
             provider: self.provider(),
             data,
+            approval: None,
         })
     }
 }

--- a/crates/swap_oneinch/Cargo.toml
+++ b/crates/swap_oneinch/Cargo.toml
@@ -7,6 +7,7 @@ version = { workspace = true }
 serde.workspace = true
 reqwest.workspace = true
 async-trait.workspace = true
+futures.workspace = true
 primitives = { path = "../primitives" }
 gem_evm = { path = "../gem_evm" }
 swap_provider = { path = "../swap_provider" }

--- a/crates/swap_oneinch/Cargo.toml
+++ b/crates/swap_oneinch/Cargo.toml
@@ -4,9 +4,9 @@ edition = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-serde = { workspace = true }
-reqwest = { workspace = true }
-async-trait = { workspace = true }
+serde.workspace = true
+reqwest.workspace = true
+async-trait.workspace = true
 primitives = { path = "../primitives" }
 gem_evm = { path = "../gem_evm" }
 swap_provider = { path = "../swap_provider" }

--- a/crates/swap_oneinch/src/client.rs
+++ b/crates/swap_oneinch/src/client.rs
@@ -46,7 +46,10 @@ impl OneInchClient {
         ]
     }
 
-    pub async fn get_tokenlist(&self, chain_id: &str) -> Result<Tokenlist, SwapError> {
+    pub async fn get_tokenlist(
+        &self,
+        chain_id: &str,
+    ) -> Result<Tokenlist, Box<dyn std::error::Error>> {
         let url = format!("{}/token/v1.2/{chain_id}", self.api_url);
         Ok(self
             .client

--- a/crates/swap_oneinch/src/client.rs
+++ b/crates/swap_oneinch/src/client.rs
@@ -99,7 +99,7 @@ impl OneInchClient {
             referrer: self.fee_referral_address.clone(),
         };
 
-        let swap_quote: SwapResult = if quote.include_data {
+        let swap_quote = if quote.include_data {
             self.get_swap_quote_data(quote_request, network_id).await?
         } else {
             self.get_swap_quote(quote_request, network_id).await?

--- a/crates/swap_oneinch/src/model.rs
+++ b/crates/swap_oneinch/src/model.rs
@@ -25,6 +25,11 @@ pub struct SwapResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwapSpender {
+    pub address: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorResponse {
     pub error: String,

--- a/crates/swapper/src/jupiter/client.rs
+++ b/crates/swapper/src/jupiter/client.rs
@@ -72,6 +72,7 @@ impl JupiterClient {
             fee_percent: self.fee as f32,
             provider: self.provider(),
             data,
+            approval: None,
         };
         Ok(quote)
     }

--- a/crates/swapper/src/thorswap/client.rs
+++ b/crates/swapper/src/thorswap/client.rs
@@ -89,6 +89,7 @@ impl ThorchainSwapClient {
             fee_percent: self.fee as f32,
             provider: self.provider(),
             data,
+            approval: None,
         };
         Ok(quote)
     }

--- a/gemstone/src/config/evm_chain.rs
+++ b/gemstone/src/config/evm_chain.rs
@@ -4,13 +4,13 @@ use primitives::EVMChain;
 pub struct EVMChainConfig {
     pub min_priority_fee: u64,
     pub is_opstack: bool,
-    pub oneinch: String,
+    pub oneinch: Vec<String>,
 }
 
 pub fn get_evm_chain_config(chain: EVMChain) -> EVMChainConfig {
     EVMChainConfig {
         min_priority_fee: chain.min_priority_fee(),
         is_opstack: chain.is_opstack(),
-        oneinch: chain.oneinch().to_string(),
+        oneinch: chain.oneinch().into_iter().map(|x| x.to_string()).collect(),
     }
 }

--- a/gemstone/src/config/evm_chain.rs
+++ b/gemstone/src/config/evm_chain.rs
@@ -4,11 +4,13 @@ use primitives::EVMChain;
 pub struct EVMChainConfig {
     pub min_priority_fee: u64,
     pub is_opstack: bool,
+    pub oneinch: String,
 }
 
 pub fn get_evm_chain_config(chain: EVMChain) -> EVMChainConfig {
     EVMChainConfig {
         min_priority_fee: chain.min_priority_fee(),
         is_opstack: chain.is_opstack(),
+        oneinch: chain.oneinch(),
     }
 }

--- a/gemstone/src/config/evm_chain.rs
+++ b/gemstone/src/config/evm_chain.rs
@@ -11,6 +11,6 @@ pub fn get_evm_chain_config(chain: EVMChain) -> EVMChainConfig {
     EVMChainConfig {
         min_priority_fee: chain.min_priority_fee(),
         is_opstack: chain.is_opstack(),
-        oneinch: chain.oneinch(),
+        oneinch: chain.oneinch().to_string(),
     }
 }


### PR DESCRIPTION
- Add 1inch router to `EVMChainConfig`
- Return `approval` with `spender`  in quote api

```json
{
  "quote": {
    "chainType": "ethereum",
    "fromAmount": "42690000000000000000",
    "toAmount": "2246134174285122",
    "feePercent": 0.0,
    "provider": {
      "name": "1inch"
    },
    "data": null,
    "approval": {
      "spender": "0x6e2b76966cbd9cf4cc2fa0d76d24d5241e0abc2f"
    }
  }
}
```