### PR TITLE
Add strum(serialize_all) for EVMChain

### DIFF
--- a/crates/primitives/src/chain_evm.rs
+++ b/crates/primitives/src/chain_evm.rs
@@ -8,6 +8,7 @@ use typeshare::typeshare;
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, EnumIter, AsRefStr, EnumString)]
 #[typeshare(swift = "Equatable, Codable, CaseIterable")]
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 pub enum EVMChain {
     Ethereum,
     SmartChain,

--- a/gemstone/tests/ios/GemTest/GemTestTests/GemTestTests.swift
+++ b/gemstone/tests/ios/GemTest/GemTestTests/GemTestTests.swift
@@ -95,4 +95,11 @@ final class GemTestTests: XCTestCase {
         XCTAssertEqual(delegations[1].validatorAddress, "0x343dA7Ff0446247ca47AA41e2A25c5Bbb230ED0A")
         XCTAssertEqual(delegations[1].amount, "1011602501587280244")
     }
+
+    func testGetEvmChainConfig() throws {
+        let config = Config().getEvmChainConfig(chain: "zksync")
+
+        XCTAssertFalse(config.isOpstack)        
+        XCTAssertEqual(config.oneinch.count, 1)
+    }
 }


### PR DESCRIPTION
To be consistent with `Chain`