### PR TITLE
Lock typeshare and diesel cli version

### DIFF
--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
       - name: Install diesel
-        run: cargo install diesel_cli --no-default-features --features postgres
+        run: make install-diesel
       - name: Run migration
         run: |
           diesel setup

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ default-members = [
 ]
 
 [workspace.dependencies]
-typeshare = "1.0.1"
+typeshare = "1.0.3"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = { version = "1.0.114" }
 tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install-diesel:
 	brew link postgresql@15
 	export LDFLAGS="-L/opt/homebrew/opt/libpq/lib"
 	export CPPFLAGS="-I/opt/homebrew/opt/libpq/include"
-	cargo install diesel_cli --no-default-features --features postgres
+	cargo install diesel_cli --no-default-features --features postgres --version 2.2.0 --force
 
 test:
 	cargo test --workspace --quiet

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install-rust:
 
 install-typeshare:
 	@echo Install typeshare-cli
-	@cargo install typeshare-cli --version 1.6.0
+	@cargo install typeshare-cli --version 1.11.0 --force
 
 install-diesel:
 	brew install libpq postgresql@15

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-install: install-rust install-typeshare install-diesel
+install: install-rust install-typeshare install-postgres install-diesel
 	@echo Install Rust
 	@curl curl https://sh.rustup.rs -sSf | sh -s -- -y
 
@@ -12,11 +12,13 @@ install-typeshare:
 	@cargo install typeshare-cli --version 1.11.0 --force
 
 install-diesel:
+	@cargo install diesel_cli --no-default-features --features postgres --version 2.2.4 --force
+
+install-postgres:
 	brew install libpq postgresql@15
 	brew link postgresql@15
 	export LDFLAGS="-L/opt/homebrew/opt/libpq/lib"
 	export CPPFLAGS="-I/opt/homebrew/opt/libpq/include"
-	cargo install diesel_cli --no-default-features --features postgres --version 2.2.0 --force
 
 test:
 	cargo test --workspace --quiet

--- a/apps/operator/src/appstore_updater.rs
+++ b/apps/operator/src/appstore_updater.rs
@@ -108,16 +108,15 @@ impl AppstoreUpdater {
             for language in languages.clone() {
                 match self.client.reviews(app.id, &language.code).await {
                     Ok(response) => {
-                        match response.feed.entry {
-                            Some(entry) => match entry {
+                        if let Some(entry) = response.feed.entry {
+                            match entry {
                                 AppStoreReviewEntries::Single(review) => values.push(Self::review(app.name.clone(), language.name.clone(), review)),
                                 AppStoreReviewEntries::Multiple(reviews) => {
                                     for review in reviews {
                                         values.push(Self::review(app.name.clone(), language.name.clone(), review))
                                     }
                                 }
-                            },
-                            None => {}
+                            }
                         }
 
                         println!("Update reviews. Found app: {}, language: {}", app.name, language.code);

--- a/crates/storage/src/schema.rs
+++ b/crates/storage/src/schema.rs
@@ -15,10 +15,10 @@ diesel::table! {
         #[max_length = 16]
         symbol -> Varchar,
         decimals -> Int4,
+        enabled -> Bool,
+        rank -> Int4,
         updated_at -> Timestamp,
         created_at -> Timestamp,
-        rank -> Int4,
-        enabled -> Bool,
     }
 }
 
@@ -48,13 +48,13 @@ diesel::table! {
         coinmarketcap -> Nullable<Varchar>,
         #[max_length = 128]
         discord -> Nullable<Varchar>,
-        updated_at -> Timestamp,
-        created_at -> Timestamp,
         is_buyable -> Bool,
         is_sellable -> Bool,
         is_swappable -> Bool,
         is_stakeable -> Bool,
         staking_apr -> Nullable<Float8>,
+        updated_at -> Timestamp,
+        created_at -> Timestamp,
     }
 }
 
@@ -89,12 +89,12 @@ diesel::table! {
         #[max_length = 8]
         locale -> Varchar,
         #[max_length = 8]
+        currency -> Varchar,
+        #[max_length = 8]
         version -> Varchar,
+        subscriptions_version -> Int4,
         updated_at -> Timestamp,
         created_at -> Timestamp,
-        #[max_length = 8]
-        currency -> Varchar,
-        subscriptions_version -> Int4,
     }
 }
 
@@ -115,9 +115,9 @@ diesel::table! {
         #[max_length = 128]
         token_id -> Nullable<Varchar>,
         enabled -> Bool,
+        hidden -> Bool,
         updated_at -> Timestamp,
         created_at -> Timestamp,
-        hidden -> Bool,
     }
 }
 
@@ -311,12 +311,12 @@ diesel::table! {
     subscriptions (id) {
         id -> Int4,
         device_id -> Int4,
+        wallet_index -> Int4,
         chain -> Varchar,
         #[max_length = 256]
         address -> Varchar,
         updated_at -> Timestamp,
         created_at -> Timestamp,
-        wallet_index -> Int4,
     }
 }
 
@@ -371,10 +371,10 @@ diesel::table! {
         fee -> Nullable<Varchar>,
         utxo_inputs -> Nullable<Jsonb>,
         utxo_outputs -> Nullable<Jsonb>,
+        metadata -> Nullable<Jsonb>,
         fee_asset_id -> Varchar,
         updated_at -> Timestamp,
         created_at -> Timestamp,
-        metadata -> Nullable<Jsonb>,
     }
 }
 


### PR DESCRIPTION
Later iOS and Android app should also install typeshare version from core to keep consistency