### PR TITLE
Return permit2 nonce and gas estimate

### DIFF
--- a/gemstone/src/swapper/mod.rs
+++ b/gemstone/src/swapper/mod.rs
@@ -6,6 +6,7 @@ use std::{fmt::Debug, sync::Arc};
 
 mod custom_types;
 mod models;
+mod permit2_data;
 mod slippage;
 mod uniswap;
 use models::*;
@@ -14,7 +15,7 @@ use models::*;
 pub trait GemSwapProvider: Send + Sync + Debug {
     fn name(&self) -> &'static str;
     async fn fetch_quote(&self, request: &SwapQuoteRequest, provider: Arc<dyn AlienProvider>) -> Result<SwapQuote, SwapperError>;
-    async fn fetch_quote_data(&self, quote: &SwapQuote, provider: Arc<dyn AlienProvider>, permit2: Option<Permit2Data>) -> Result<SwapQuoteData, SwapperError>;
+    async fn fetch_quote_data(&self, quote: &SwapQuote, provider: Arc<dyn AlienProvider>, data: FetchQuoteData) -> Result<SwapQuoteData, SwapperError>;
 }
 
 #[derive(Debug, uniffi::Object)]
@@ -46,12 +47,12 @@ impl GemSwapper {
         Err(SwapperError::NoQuoteAvailable)
     }
 
-    async fn fetch_quote_data(&self, quote: &SwapQuote, permit2: Option<Permit2Data>) -> Result<SwapQuoteData, SwapperError> {
+    async fn fetch_quote_data(&self, quote: &SwapQuote, data: FetchQuoteData) -> Result<SwapQuoteData, SwapperError> {
         let swapper = self
             .swappers
             .iter()
             .find(|x| x.name() == quote.provider.name.as_str())
             .ok_or(SwapperError::NotImplemented)?;
-        swapper.fetch_quote_data(quote, self.rpc_provider.clone(), permit2).await
+        swapper.fetch_quote_data(quote, self.rpc_provider.clone(), data).await
     }
 }

--- a/gemstone/src/swapper/models.rs
+++ b/gemstone/src/swapper/models.rs
@@ -1,16 +1,7 @@
-use alloy_core::primitives::{Address, Bytes, U256};
-use alloy_primitives::aliases::{U160, U48};
-use serde::{Deserialize, Serialize, Serializer};
-use std::{
-    fmt::{Debug, Display},
-    str::FromStr,
-};
+use primitives::{AssetId, ChainType};
+use std::fmt::Debug;
 
-use gem_evm::{
-    permit2::{IAllowanceTransfer, Permit2Types},
-    uniswap::{command::Permit2Permit, deployment::get_deployment_by_chain},
-};
-use primitives::{eip712::EIP712Domain, AssetId, Chain, ChainType};
+use super::permit2_data::Permit2Data;
 
 static DEFAULT_SLIPPAGE_BPS: u32 = 300;
 
@@ -85,7 +76,7 @@ pub struct SwapQuote {
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum ApprovalType {
     Approve(ApprovalData),
-    Permit2(ApprovalData),
+    Permit2(Permit2ApprovalData),
     None,
 }
 
@@ -94,7 +85,14 @@ pub struct ApprovalData {
     pub token: String,
     pub spender: String,
     pub value: String,
-    pub permit2_nonce: Option<u64>, // Optional permit2 nonce
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct Permit2ApprovalData {
+    pub token: String,
+    pub spender: String,
+    pub value: String,
+    pub permit2_nonce: u64,
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
@@ -119,112 +117,8 @@ pub struct SwapRoute {
     pub gas_estimate: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
-pub struct Permit2Detail {
-    pub token: String,
-    pub amount: String,
-    #[serde(serialize_with = "serialize_as_string")]
-    pub expiration: u64,
-    #[serde(serialize_with = "serialize_as_string")]
-    pub nonce: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
-pub struct PermitSingle {
-    pub details: Permit2Detail,
-    pub spender: String,
-    #[serde(rename = "sigDeadline", serialize_with = "serialize_as_string")]
-    pub sig_deadline: u64,
-}
-
-impl From<PermitSingle> for IAllowanceTransfer::PermitSingle {
-    fn from(val: PermitSingle) -> Self {
-        IAllowanceTransfer::PermitSingle {
-            details: IAllowanceTransfer::PermitDetails {
-                token: Address::parse_checksummed(val.details.token, None).unwrap(),
-                amount: U160::from_str(&val.details.amount).unwrap(),
-                expiration: U48::from(val.details.expiration),
-                nonce: U48::from(val.details.nonce),
-            },
-            spender: Address::parse_checksummed(val.spender, None).unwrap(),
-            sigDeadline: U256::from(val.sig_deadline),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
-pub struct Permit2Data {
-    pub permit_single: PermitSingle,
-    pub signature: Vec<u8>,
-}
-
-impl From<Permit2Data> for Permit2Permit {
-    fn from(val: Permit2Data) -> Self {
-        Permit2Permit {
-            permit_single: val.permit_single.into(),
-            signature: Bytes::from(val.signature),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Permit2Message {
-    domain: EIP712Domain,
-    types: Permit2Types,
-    #[serde(rename = "primaryType")]
-    primary_type: String,
-    message: PermitSingle,
-}
-
-fn serialize_as_string<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
-where
-    T: Display,
-    S: Serializer,
-{
-    serializer.serialize_str(&value.to_string())
-}
-
-#[uniffi::export]
-pub fn permit2_data_to_eip712_json(chain: Chain, data: PermitSingle) -> Result<String, SwapperError> {
-    let chain_id = chain.network_id();
-    let contract = get_deployment_by_chain(chain).ok_or(SwapperError::NotImplemented)?.permit2;
-    let message = Permit2Message {
-        domain: EIP712Domain {
-            name: "Permit2".to_string(),
-            version: "".into(),
-            chain_id: chain_id.parse::<u32>().unwrap(),
-            verifying_contract: contract.to_string(),
-        },
-        types: Permit2Types::default(),
-        primary_type: "PermitSingle".into(),
-        message: data,
-    };
-    let json = serde_json::to_string(&message).map_err(|_| SwapperError::ABIError {
-        msg: "failed to serialize EIP712 message to JSON".into(),
-    })?;
-    Ok(json)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn test_permit2_data_eip712_json() {
-        let data = PermitSingle {
-            details: Permit2Detail {
-                token: "0xdAC17F958D2ee523a2206206994597C13D831ec7".into(),
-                amount: "1461501637330902918203684832716283019655932542975".into(),
-                expiration: 1732780554,
-                nonce: 0,
-            },
-            spender: "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD".into(),
-            sig_deadline: 1730190354,
-        };
-
-        let json = permit2_data_to_eip712_json(Chain::Ethereum, data).unwrap();
-        assert_eq!(
-            json,
-            r#"{"domain":{"name":"Permit2","chainId":1,"verifyingContract":"0x000000000022D473030F116dDEE9F6B43aC78BA3"},"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"PermitSingle":[{"name":"details","type":"PermitDetails"},{"name":"spender","type":"address"},{"name":"sigDeadline","type":"uint256"}],"PermitDetails":[{"name":"token","type":"address"},{"name":"amount","type":"uint160"},{"name":"expiration","type":"uint48"},{"name":"nonce","type":"uint48"}]},"primaryType":"PermitSingle","message":{"details":{"token":"0xdAC17F958D2ee523a2206206994597C13D831ec7","amount":"1461501637330902918203684832716283019655932542975","expiration":"1732780554","nonce":"0"},"spender":"0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD","sigDeadline":"1730190354"}}"#
-        );
-    }
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum FetchQuoteData {
+    Permit2(Permit2Data),
+    None,
 }

--- a/gemstone/src/swapper/permit2_data.rs
+++ b/gemstone/src/swapper/permit2_data.rs
@@ -1,0 +1,124 @@
+use crate::swapper::SwapperError;
+use alloy_core::primitives::{Address, Bytes, U256};
+use alloy_primitives::aliases::{U160, U48};
+use serde::{Deserialize, Serialize, Serializer};
+use std::{
+    fmt::{Debug, Display},
+    str::FromStr,
+};
+
+use gem_evm::{
+    permit2::{IAllowanceTransfer, Permit2Types},
+    uniswap::{command::Permit2Permit, deployment::get_deployment_by_chain},
+};
+use primitives::{eip712::EIP712Domain, Chain};
+
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct Permit2Detail {
+    pub token: String,
+    pub amount: String,
+    #[serde(serialize_with = "serialize_as_string")]
+    pub expiration: u64,
+    #[serde(serialize_with = "serialize_as_string")]
+    pub nonce: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct PermitSingle {
+    pub details: Permit2Detail,
+    pub spender: String,
+    #[serde(rename = "sigDeadline", serialize_with = "serialize_as_string")]
+    pub sig_deadline: u64,
+}
+
+impl From<PermitSingle> for IAllowanceTransfer::PermitSingle {
+    fn from(val: PermitSingle) -> Self {
+        IAllowanceTransfer::PermitSingle {
+            details: IAllowanceTransfer::PermitDetails {
+                token: Address::parse_checksummed(val.details.token, None).unwrap(),
+                amount: U160::from_str(&val.details.amount).unwrap(),
+                expiration: U48::from(val.details.expiration),
+                nonce: U48::from(val.details.nonce),
+            },
+            spender: Address::parse_checksummed(val.spender, None).unwrap(),
+            sigDeadline: U256::from(val.sig_deadline),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct Permit2Data {
+    pub permit_single: PermitSingle,
+    pub signature: Vec<u8>,
+}
+
+impl From<Permit2Data> for Permit2Permit {
+    fn from(val: Permit2Data) -> Self {
+        Permit2Permit {
+            permit_single: val.permit_single.into(),
+            signature: Bytes::from(val.signature),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Permit2Message {
+    domain: EIP712Domain,
+    types: Permit2Types,
+    #[serde(rename = "primaryType")]
+    primary_type: String,
+    message: PermitSingle,
+}
+
+fn serialize_as_string<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: Display,
+    S: Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}
+
+#[uniffi::export]
+pub fn permit2_data_to_eip712_json(chain: Chain, data: PermitSingle) -> Result<String, SwapperError> {
+    let chain_id = chain.network_id();
+    let contract = get_deployment_by_chain(chain).ok_or(SwapperError::NotImplemented)?.permit2;
+    let message = Permit2Message {
+        domain: EIP712Domain {
+            name: "Permit2".to_string(),
+            version: "".into(),
+            chain_id: chain_id.parse::<u32>().unwrap(),
+            verifying_contract: contract.to_string(),
+        },
+        types: Permit2Types::default(),
+        primary_type: "PermitSingle".into(),
+        message: data,
+    };
+    let json = serde_json::to_string(&message).map_err(|_| SwapperError::ABIError {
+        msg: "failed to serialize EIP712 message to JSON".into(),
+    })?;
+    Ok(json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_permit2_data_eip712_json() {
+        let data = PermitSingle {
+            details: Permit2Detail {
+                token: "0xdAC17F958D2ee523a2206206994597C13D831ec7".into(),
+                amount: "1461501637330902918203684832716283019655932542975".into(),
+                expiration: 1732780554,
+                nonce: 0,
+            },
+            spender: "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD".into(),
+            sig_deadline: 1730190354,
+        };
+
+        let json = permit2_data_to_eip712_json(Chain::Ethereum, data).unwrap();
+        assert_eq!(
+            json,
+            r#"{"domain":{"name":"Permit2","chainId":1,"verifyingContract":"0x000000000022D473030F116dDEE9F6B43aC78BA3"},"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"PermitSingle":[{"name":"details","type":"PermitDetails"},{"name":"spender","type":"address"},{"name":"sigDeadline","type":"uint256"}],"PermitDetails":[{"name":"token","type":"address"},{"name":"amount","type":"uint160"},{"name":"expiration","type":"uint48"},{"name":"nonce","type":"uint48"}]},"primaryType":"PermitSingle","message":{"details":{"token":"0xdAC17F958D2ee523a2206206994597C13D831ec7","amount":"1461501637330902918203684832716283019655932542975","expiration":"1732780554","nonce":"0"},"spender":"0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD","sigDeadline":"1730190354"}}"#
+        );
+    }
+}

--- a/gemstone/tests/ios/GemTest/GemTest/ContentView.swift
+++ b/gemstone/tests/ios/GemTest/GemTest/ContentView.swift
@@ -7,6 +7,26 @@ struct ContentView: View {
 
     let provider = NativeProvider()
 
+    let eth2usdcRequest: SwapQuoteRequest = SwapQuoteRequest(
+        fromAsset: "ethereum",
+        toAsset: "ethereum_0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        walletAddress: "0x514BCb1F9AAbb904e6106Bd1052B66d2706dBbb7",
+        destinationAddress: "0x514BCb1F9AAbb904e6106Bd1052B66d2706dBbb7",
+        value: "100000000000000000", // 0.01 ETH
+        mode: .exactIn,
+        options: nil
+    )
+
+    let usdc2ethRequest: SwapQuoteRequest = SwapQuoteRequest(
+        fromAsset: "ethereum_0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        toAsset: "ethereum",
+        walletAddress: "0x514BCb1F9AAbb904e6106Bd1052B66d2706dBbb7",
+        destinationAddress: "0x514BCb1F9AAbb904e6106Bd1052B66d2706dBbb7",
+        value: "100000000", // 100 USDC
+        mode: .exactIn,
+        options: nil
+    )
+
     var body: some View {
         VStack {
             Image(systemName: "diamond")
@@ -53,15 +73,7 @@ struct ContentView: View {
 
     func fetchQuote() async throws {
         // ETH -> USDC
-        let request = SwapQuoteRequest(
-            fromAsset: "ethereum",
-            toAsset: "ethereum_0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-            walletAddress: "0x514BCb1F9AAbb904e6106Bd1052B66d2706dBbb7",
-            destinationAddress: "0x514BCb1F9AAbb904e6106Bd1052B66d2706dBbb7",
-            value: "100000000000000000",
-            mode: .exactIn,
-            options: nil
-        )
+        let request = self.usdc2ethRequest
 
         let swapper = GemSwapper(rpcProvider: NativeProvider())
         guard let quote = try await swapper.fetchQuote(request: request).first else {

--- a/gemstone/tests/ios/GemTest/GemTest/ContentView.swift
+++ b/gemstone/tests/ios/GemTest/GemTest/ContentView.swift
@@ -81,7 +81,7 @@ struct ContentView: View {
         }
         print("<== fetchQuote:\n", quote)
 
-        let data = try await swapper.fetchQuoteData(quote: quote, permit2: nil)
+        let data = try await swapper.fetchQuoteData(quote: quote, data: .none)
         print("<== fetchQuoteData:\n", data)
     }
 }


### PR DESCRIPTION
Other changes:
1. return `Result` for `permit2_data_to_eip712_json`
2. return optional permit2 nonce to approval data
3. return optional gas estimate in `SwapRoute`
4. add generic `FetchQuoteData` enum