### PR TITLE
Fix permit2 spender typo

### DIFF
--- a/gemstone/src/swapper/approval.rs
+++ b/gemstone/src/swapper/approval.rs
@@ -70,7 +70,7 @@ pub async fn check_approval(check_type: CheckApprovalType, provider: Arc<dyn Ali
         CheckApprovalType::ERC20(owner, token, spender, amount) => check_approval_erc20(owner, token, spender, amount, provider, chain).await,
         CheckApprovalType::Permit2(permit2_contract, owner, token, spender, amount) => {
             // Check token allowance, spender is permit2
-            let self_approval = check_approval_erc20(owner.clone(), token.clone(), spender.clone(), amount, provider.clone(), chain).await?;
+            let self_approval = check_approval_erc20(owner.clone(), token.clone(), permit2_contract.clone(), amount, provider.clone(), chain).await?;
 
             // Return self_approval if it's not None
             if matches!(self_approval, ApprovalType::Approve(_)) {


### PR DESCRIPTION
Fix typo error, first approval spender should be permit 