### PR TITLE
Remove `Ethereum` case from `StakeChain`

### DIFF
--- a/crates/primitives/src/chain_stake.rs
+++ b/crates/primitives/src/chain_stake.rs
@@ -16,7 +16,6 @@ pub enum StakeChain {
     Solana,
     Sui,
     SmartChain,
-    Ethereum,
     Tron,
 }
 
@@ -29,14 +28,13 @@ impl StakeChain {
             Self::Sui => 86400,
             Self::Osmosis | Self::Tron => 1_209_600,
             Self::SmartChain => 604800,
-            Self::Ethereum => 86400, // ~1 day https://stake.lido.fi/withdrawals/request#withdrawalsPeriod
         }
     }
 
     /// Get the minimum stake amount
     pub fn get_min_stake_amount(&self) -> u64 {
         match self {
-            Self::Cosmos | Self::Injective | Self::Sei | Self::Celestia | Self::Osmosis | Self::Ethereum => 0,
+            Self::Cosmos | Self::Injective | Self::Sei | Self::Celestia | Self::Osmosis => 0,
             Self::Solana => 10_000_000,                    // 0.01 SOL
             Self::Sui => 1_000_000_000,                    // 1 SUI
             Self::SmartChain => 1_000_000_000_000_000_000, // 1 BNB
@@ -47,7 +45,7 @@ impl StakeChain {
     /// Get if chain support ability to change amount on unstake
     pub fn get_change_amount_on_unstake(&self) -> bool {
         match self {
-            Self::Cosmos | Self::Osmosis | Self::Injective | Self::Sei | Self::Celestia | Self::Solana | Self::SmartChain | Self::Ethereum | Self::Tron => true,
+            Self::Cosmos | Self::Osmosis | Self::Injective | Self::Sei | Self::Celestia | Self::Solana | Self::SmartChain | Self::Tron => true,
             Self::Sui => false,
         }
     }
@@ -56,21 +54,21 @@ impl StakeChain {
     pub fn get_can_redelegate(&self) -> bool {
         match self {
             Self::Cosmos | Self::Osmosis | Self::Injective | Self::Sei | Self::Celestia | Self::SmartChain | Self::Tron => true,
-            Self::Sui | Self::Solana | Self::Ethereum => false,
+            Self::Sui | Self::Solana => false,
         }
     }
 
     pub fn get_can_withdraw(&self) -> bool {
         match self {
             Self::Solana | Self::Tron | Self::SmartChain => true,
-            Self::Cosmos | Self::Osmosis | Self::Injective | Self::Sei | Self::Celestia | Self::Sui | Self::Ethereum => false,
+            Self::Cosmos | Self::Osmosis | Self::Injective | Self::Sei | Self::Celestia | Self::Sui => false,
         }
     }
 
     pub fn get_can_claim_rewards(&self) -> bool {
         match self {
             Self::Cosmos | Self::Osmosis | Self::Injective | Self::Sei | Self::Celestia | Self::Tron => true,
-            Self::SmartChain | Self::Sui | Self::Solana | Self::Ethereum => false,
+            Self::SmartChain | Self::Sui | Self::Solana => false,
         }
     }
 }


### PR DESCRIPTION
This was added for lido (liquid staking) not really native staking