### PR TITLE
Add `Rootstock` (EVM compatible bitcoin sidechain)

### DIFF
--- a/Settings.yaml
+++ b/Settings.yaml
@@ -145,6 +145,8 @@ chains:
     url: https://horizon.stellar.org
   sonic:
     url: https://rpc.soniclabs.com
+  rootstock:
+    url: https://public-node.rsk.co
   algorand:
     url: https://mainnet-api.algonode.cloud
   polkadot:

--- a/crates/chain_primitives/src/lib.rs
+++ b/crates/chain_primitives/src/lib.rs
@@ -21,6 +21,7 @@ pub fn format_token_id(chain: Chain, token_id: String) -> Option<String> {
         | Chain::Celo
         | Chain::World
         | Chain::Sonic
+        | Chain::Rootstock
         | Chain::Abstract
         | Chain::Berachain
         | Chain::Ink

--- a/crates/coingecko/src/mapper.rs
+++ b/crates/coingecko/src/mapper.rs
@@ -47,6 +47,7 @@ pub fn get_chain_for_coingecko_platform_id(id: &str) -> Option<Chain> {
         "xrp" => Some(Chain::Xrp),
         "hyperliquid" => Some(Chain::Hyperliquid),
         "sonic" => Some(Chain::Sonic),
+        "rootstock" => Some(Chain::Rootstock),
         _ => None,
     }
 }
@@ -98,5 +99,6 @@ pub fn get_coingecko_market_id_for_chain(chain: Chain) -> &'static str {
         Chain::Berachain => "berachain-bera",
         Chain::Hyperliquid => "hyperliquid",
         Chain::Monad => "monad",
+        Chain::Rootstock => "rootstock",
     }
 }

--- a/crates/fiat/src/providers/banxa/mapper.rs
+++ b/crates/fiat/src/providers/banxa/mapper.rs
@@ -35,6 +35,7 @@ pub fn map_asset_chain(chain: String) -> Option<Chain> {
         "S" => Some(Chain::Sonic),
         "INJ" => Some(Chain::Injective),
         "MNT" => Some(Chain::Mantle),
+        "RBTC" => Some(Chain::Rootstock),
         _ => None,
     }
 }

--- a/crates/fiat/src/providers/moonpay/mapper.rs
+++ b/crates/fiat/src/providers/moonpay/mapper.rs
@@ -39,6 +39,7 @@ pub fn map_asset_chain(asset: Asset) -> Option<Chain> {
         "bitcoin_cash" => Some(Chain::BitcoinCash),
         "mantle" => Some(Chain::Mantle),
         "sonic" => Some(Chain::Sonic),
+        "rootstock" => Some(Chain::Rootstock),
         _ => None,
     }
 }

--- a/crates/gem_evm/src/multicall3.rs
+++ b/crates/gem_evm/src/multicall3.rs
@@ -85,6 +85,7 @@ pub fn deployment_by_chain(chain: &EVMChain) -> &'static str {
         | EVMChain::Berachain
         | EVMChain::Ink
         | EVMChain::Unichain
+        | EVMChain::Rootstock
         | EVMChain::Hyperliquid => "0xcA11bde05977b3631167028862bE2a173976CA11",
         EVMChain::ZkSync | EVMChain::Abstract => "0xF9cda624FBC7e059355ce98a31693d299FACd963",
         EVMChain::Monad => "", //TODO: Monad

--- a/crates/gem_evm/src/uniswap/deployment/v3.rs
+++ b/crates/gem_evm/src/uniswap/deployment/v3.rs
@@ -80,6 +80,11 @@ pub fn get_uniswap_router_deployment_by_chain(chain: &Chain) -> Option<V3Deploym
             permit2,
             universal_router: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D",
         }),
+        Chain::Rootstock => Some(V3Deployment {
+            quoter_v2: "0xb51727c996C68E60F598A923a5006853cd2fEB31",
+            permit2: "0xFcf5986450E4A014fFE7ad4Ae24921B589D039b5",
+            universal_router: "0x244f68e77357f86a8522323eBF80b5FC2F814d3E",
+        }),
 
         Chain::Unichain => Some(V3Deployment {
             quoter_v2: "0x385A5cf5F83e99f7BB2852b6A19C3538b9FA7658",
@@ -120,6 +125,11 @@ pub fn get_oku_deployment_by_chain(chain: &Chain) -> Option<V3Deployment> {
             quoter_v2: "0x5911cB3633e764939edc2d92b7e1ad375Bb57649",
             universal_router: "0x738fD6d10bCc05c230388B4027CAd37f82fe2AF2",
             permit2: "0xB952578f3520EE8Ea45b7914994dcf4702cEe578",
+        }),
+        Chain::Rootstock => Some(V3Deployment {
+            quoter_v2: "0xb51727c996C68E60F598A923a5006853cd2fEB31",
+            universal_router: "0x244f68e77357f86a8522323eBF80b5FC2F814d3E",
+            permit2: "0xFcf5986450E4A014fFE7ad4Ae24921B589D039b5",
         }),
         Chain::Mantle => Some(V3Deployment {
             quoter_v2: "0xdD489C75be1039ec7d843A6aC2Fd658350B067Cf",

--- a/crates/gem_evm/src/uniswap/path.rs
+++ b/crates/gem_evm/src/uniswap/path.rs
@@ -93,6 +93,7 @@ pub fn get_base_pair(chain: &EVMChain, weth_as_native: bool) -> Option<BasePair>
         EVMChain::Blast => "0xf7bc58b8d8f97adc129cfc4c9f45ce3c0e1d2692",
         EVMChain::World => "0x03C7054BCB39f7b2e5B2c7AcB37583e32D70Cfa3",
         EVMChain::Sonic => "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
+        EVMChain::Rootstock => "0x542fda317318ebf1d3deaf76e0b632741a7e677d",
         EVMChain::Linea => "0x3aAB2285ddcDdaD8edf438C1bAB47e1a9D05a9b4",
         _ => "", // None
     };
@@ -111,7 +112,8 @@ pub fn get_base_pair(chain: &EVMChain, weth_as_native: bool) -> Option<BasePair>
         EVMChain::World => "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1",    // USDC.e
         EVMChain::Abstract => "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1", // USDC.e
         EVMChain::Unichain => "0x078d782b760474a361dda0af3839290b0ef57ad6",
-        EVMChain::Sonic => "0x29219dd400f2bf60e5a23d13be72b486d4038894", // USDC.e
+        EVMChain::Sonic => "0x29219dd400f2bf60e5a23d13be72b486d4038894",     // USDC.e
+        EVMChain::Rootstock => "0x74C9F2B00581F1b11Aa7Ff05aa9f608B7389de67", // USDC.e, Bridged USDC (Stargate)
         EVMChain::Mantle => "0x09Bc4E0D864854c6aFB6eB9A9cdF58aC190D0dF9",
         EVMChain::Gnosis => "0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0", // USDC.e
         EVMChain::Manta => "0xb73603c5d87fa094b7314c74ace2e64d165016fb",
@@ -134,6 +136,7 @@ pub fn get_base_pair(chain: &EVMChain, weth_as_native: bool) -> Option<BasePair>
         EVMChain::Abstract => "0x0709F39376dEEe2A2dfC94A58EdEb2Eb9DF012bD",
         EVMChain::Unichain => "0x9151434b16b9763660705744891fA906F660EcC5", // USDT0
         EVMChain::Sonic => "0x6047828dc181963ba44974801FF68e538dA5eaF9",
+        EVMChain::Rootstock => "0xaf368c91793cb22739386dfcbbb2f1a9e4bcbebf",
         EVMChain::Mantle => "0x201EBa5CC46D216Ce6DC03F6a759e8E766e956aE",
         EVMChain::Gnosis => "0x4ECaBa5870353805a9F068101A40E0f32ed605C6",
         EVMChain::Manta => "0xf417f5a458ec102b90352f697d6e2ac3a3d2851f",

--- a/crates/pricer_dex/src/pyth/mapper.rs
+++ b/crates/pricer_dex/src/pyth/mapper.rs
@@ -46,6 +46,7 @@ pub fn price_account_for_chain(chain: Chain) -> &'static str {
         Chain::Hyperliquid => "5UVhvt9NzyyVuVaePfkaEaHD6hoD9Dw7PFUCfRoMh8i6",
         Chain::Fantom | Chain::Sonic => "HTgSrKu2XfDc7wEm9ZJn6tavhKFD6EHNcnEBxBsArFzL",
         Chain::Gnosis => "CtJ8EkqLmeYyGB8s4jevpeNsvmD4dxVR2krfsDLcvV8Y",
+        Chain::Rootstock => "",
         Chain::Monad => "Gnt27xtC473ZT2Mw5u8wZ68Z3gULkSTb5DuxJy7eJotD", //TODO: Monad. USDC. FIX in the future.
     }
 }

--- a/crates/primitives/src/asset.rs
+++ b/crates/primitives/src/asset.rs
@@ -93,6 +93,7 @@ impl Asset {
             Chain::World => chain.new_asset("World".to_string(), "ETH".to_string(), 18, AssetType::NATIVE),
             Chain::Stellar => chain.new_asset("Stellar".to_string(), "XLM".to_string(), 7, AssetType::NATIVE),
             Chain::Sonic => chain.new_asset("Sonic".to_string(), "S".to_string(), 18, AssetType::NATIVE),
+            Chain::Rootstock => chain.new_asset("RBTC".to_string(), "RBTC".to_string(), 18, AssetType::NATIVE),
             Chain::Algorand => chain.new_asset("Algorand".to_string(), "ALGO".to_string(), 6, AssetType::NATIVE),
             Chain::Polkadot => chain.new_asset("Polkadot".to_string(), "DOT".to_string(), 10, AssetType::NATIVE),
             Chain::Cardano => chain.new_asset("Cardano".to_string(), "ADA".to_string(), 6, AssetType::NATIVE),

--- a/crates/primitives/src/block_explorer.rs
+++ b/crates/primitives/src/block_explorer.rs
@@ -91,6 +91,7 @@ pub fn get_block_explorers(chain: Chain) -> Vec<Box<dyn BlockExplorer>> {
         Chain::Ink => vec![RouteScan::new_ink(), BlockScout::new_ink(), OkxExplorer::new_ink()],
         Chain::Unichain => vec![EtherScan::new(EVMChain::Unichain)],
         Chain::Hyperliquid => vec![BlockScout::new_hyperliquid(), HyperLiquid::new()],
+        Chain::Rootstock => vec![BlockScout::new_rootstock(), EtherScan::new(EVMChain::Rootstock)],
         Chain::Monad => vec![EtherScan::new(EVMChain::Monad)],
     }
 }

--- a/crates/primitives/src/chain.rs
+++ b/crates/primitives/src/chain.rs
@@ -58,6 +58,7 @@ pub enum Chain {
     Unichain,
     Hyperliquid,
     Monad,
+    Rootstock,
 }
 
 impl fmt::Display for Chain {
@@ -133,6 +134,7 @@ impl Chain {
             Self::Unichain => "130",
             Self::Hyperliquid => "999",
             Self::Monad => "10143", //TODO: Monad 143
+            Self::Rootstock => "30",
         }
     }
 
@@ -188,6 +190,7 @@ impl Chain {
             Self::Algorand => 283,
             Self::Polkadot => 354,
             Self::Cardano => 1815,
+            Self::Rootstock => 137,
         }
     }
 
@@ -216,6 +219,7 @@ impl Chain {
             | Self::Ink
             | Self::Unichain
             | Self::Hyperliquid
+            | Self::Rootstock
             | Self::Monad => ChainType::Ethereum,
             Self::Bitcoin | Self::BitcoinCash | Self::Doge | Self::Litecoin => ChainType::Bitcoin,
             Self::Solana => ChainType::Solana,
@@ -256,6 +260,7 @@ impl Chain {
             | Self::Ink
             | Self::Unichain
             | Self::Hyperliquid
+            | Self::Rootstock
             | Self::Monad => Some(AssetType::ERC20),
             Self::OpBNB | Self::SmartChain => Some(AssetType::BEP20),
             Self::Solana => Some(AssetType::SPL),
@@ -335,6 +340,7 @@ impl Chain {
             | Self::Doge
             | Self::Aptos
             | Self::Sonic
+            | Self::Rootstock
             | Self::Abstract
             | Self::Unichain
             | Self::Ink
@@ -401,6 +407,7 @@ impl Chain {
             Self::Cardano => 20_000,
             Self::Doge => 60_000,
             Self::Litecoin => 120_000,
+            Self::Rootstock => 30_000,
             Self::Bitcoin | Self::BitcoinCash => 600_000,
         }
     }
@@ -444,6 +451,7 @@ impl Chain {
             | Self::World
             | Self::Stellar
             | Self::Sonic
+            | Self::Rootstock
             | Self::Algorand
             | Self::Cardano => 30,
             Self::Noble => 20,

--- a/crates/primitives/src/chain_evm.rs
+++ b/crates/primitives/src/chain_evm.rs
@@ -41,6 +41,7 @@ pub enum EVMChain {
     Unichain,
     Hyperliquid,
     Monad,
+    Rootstock,
 }
 
 impl EVMChain {
@@ -65,6 +66,7 @@ impl EVMChain {
             Self::Linea => 50_000_000,    // https://lineascan.build/gastracker
             Self::Mantle | Self::Celo | Self::Manta => 10_000_000,
             Self::Sonic => 10_000_000,
+            Self::Rootstock => 0, // no priority fee, safe dummy value
             Self::Berachain => 1_000_000_000,   // 1 Gwei
             Self::Hyperliquid => 1_000_000_000, // 1 Gwei
             Self::Monad => 1_000_000_000,       // 1 Gwei
@@ -88,6 +90,7 @@ impl EVMChain {
             | Self::Mantle
             | Self::Sonic
             | Self::Berachain
+            | Self::Rootstock
             | Self::Hyperliquid
             | Self::Monad => ChainStack::Native,
         }
@@ -142,6 +145,7 @@ impl EVMChain {
             Self::Mantle => Some("0x78c1b0C915c4FAA5FffA6CAbf0219DA63d7f4cb8"), // Wrapped Mantle (WMNT)
             Self::Manta => Some("0x0dc808adce2099a9f62aa87d9670745aba741746"),
             Self::Monad => None, //TODO: Monad
+            Self::Rootstock => Some("0x2F6f07CDcf3588944bF4C42Ac74fF24bf56e7590"),
         }
     }
 

--- a/crates/primitives/src/explorers/blockscout.rs
+++ b/crates/primitives/src/explorers/blockscout.rs
@@ -15,6 +15,15 @@ impl BlockScout {
         })
     }
 
+    pub fn new_rootstock() -> Box<Self> {
+        Box::new(Self {
+            meta: Metadata {
+                name: BLOCK_SCOUT,
+                base_url: "https://rootstock.blockscout.com",
+            },
+        })
+    }
+
     pub fn new_manta() -> Box<Self> {
         Box::new(Self {
             meta: Metadata {

--- a/crates/primitives/src/explorers/etherscan.rs
+++ b/crates/primitives/src/explorers/etherscan.rs
@@ -116,6 +116,12 @@ impl EtherScan {
                     base_url: "https://sonicscan.org",
                 },
             },
+            EVMChain::Rootstock => Self {
+                meta: Metadata {
+                    name: "Rootstock explorer",
+                    base_url: "https://explorer.rootstock.io",
+                },
+            },
             EVMChain::Abstract => Self {
                 meta: Metadata {
                     name: "Abscan",

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -211,6 +211,7 @@ pub struct Chains {
     pub world: Chain,
     pub stellar: Chain,
     pub sonic: Chain,
+    pub rootstock: Chain,
     pub algorand: Chain,
     pub polkadot: Chain,
     pub cardano: Chain,

--- a/crates/settings_chain/src/lib.rs
+++ b/crates/settings_chain/src/lib.rs
@@ -63,6 +63,7 @@ impl ProviderFactory {
             | Chain::Celo
             | Chain::World
             | Chain::Sonic
+            | Chain::Rootstock
             | Chain::Abstract
             | Chain::Berachain
             | Chain::Ink
@@ -128,6 +129,7 @@ impl ProviderFactory {
             Chain::World => settings.chains.world.url.as_str(),
             Chain::Stellar => settings.chains.stellar.url.as_str(),
             Chain::Sonic => settings.chains.sonic.url.as_str(),
+            Chain::Rootstock => settings.chains.rootstock.url.as_str(),
             Chain::Algorand => settings.chains.algorand.url.as_str(),
             Chain::Polkadot => settings.chains.polkadot.url.as_str(),
             Chain::Cardano => settings.chains.cardano.url.as_str(),

--- a/gemstone/src/config/node.rs
+++ b/gemstone/src/config/node.rs
@@ -148,6 +148,10 @@ pub fn get_nodes_for_chain(chain: Chain) -> Vec<Node> {
             Node::new("https://mainnet.unichain.org", NodePriority::High),
             Node::new("https://unichain-rpc.publicnode.com", NodePriority::High),
         ],
+        Chain::Rootstock => vec![
+            Node::new("https://public-node.rsk.co", NodePriority::High),
+            Node::new("https://mycrypto.rsk.co", NodePriority::High),
+        ],
         Chain::Hyperliquid => vec![Node::new("https://rpc.hyperliquid.xyz/evm", NodePriority::High)],
         Chain::Monad => vec![], //TODO: Monad
     }


### PR DESCRIPTION
## Description

This PR adds [Rootstock](https://rootstock.io/) chain (evm compatible bitcoin sidechain) to gem wallet core library. 
**Rootstock** is the leading Bitcoin Layer 2 (**Bitcoin sidechain**) network with strong **DeFi traction**, **fully EVM compatible** with **security** of **bitcoin** (with BTC hash rate ~85%) supported by the **leading developer tools**; **oracles**, indexers, Rootstock is the most advanced and complete **infrastructure for building on Bitcoin**.

## About Rootstock
Website: https://rootstock.io/
Defillama: https://defillama.com/chain/Rootstock
Explorer: https://explorer.rootstock.io/
Developer portal: https://dev.rootstock.io/


Need this PR to be included in core library so that support for Rootstock in gemwallet mobile apps could be added. Please review this pull request and feel free to let me know/comment if there any changes required.