### PR TITLE
Update Chainflip block explorer tx endpoint

### DIFF
--- a/crates/gem_ton/src/cell/parser.rs
+++ b/crates/gem_ton/src/cell/parser.rs
@@ -16,11 +16,7 @@ pub struct CellParser<'a> {
 impl CellParser<'_> {
     pub fn remaining_bits(&mut self) -> usize {
         let pos = self.bit_reader.position_in_bits().unwrap_or_default() as usize;
-        if self.bit_len > pos {
-            self.bit_len - pos
-        } else {
-            0
-        }
+        self.bit_len.saturating_sub(pos)
     }
 
     /// Return number of full bytes remaining

--- a/crates/primitives/src/explorers/chainflip.rs
+++ b/crates/primitives/src/explorers/chainflip.rs
@@ -20,10 +20,25 @@ impl BlockExplorer for ChainflipScan {
         self.meta.name.into()
     }
     fn get_tx_url(&self, hash: &str) -> String {
-        // it's not hash but swap id
-        format!("{}/swaps/{}", self.meta.base_url, hash)
+        format!("{}/tx/{}", self.meta.base_url, hash)
     }
     fn get_address_url(&self, _address: &str) -> String {
         "".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chainflip_scan() {
+        let chainflip_scan = ChainflipScan::new();
+        let tx = "54qsbkVUPoQUbwfuQeDXmNyodPWVX8VcK6sSSFyfezkg8t5XbduthFisKBcGxGjSab8QsKaPoEWEnzsK9xsFXrMF";
+        assert_eq!(chainflip_scan.name(), "Chainflip");
+        assert_eq!(
+            chainflip_scan.get_tx_url(tx),
+            "https://scan.chainflip.io/tx/54qsbkVUPoQUbwfuQeDXmNyodPWVX8VcK6sSSFyfezkg8t5XbduthFisKBcGxGjSab8QsKaPoEWEnzsK9xsFXrMF"
+        );
     }
 }


### PR DESCRIPTION
Now /tx/{hash} will redirect to /swaps/{id} automatically