### PR TITLE
WalletConnect documentation URL to DocsUrl enum

### DIFF
--- a/gemstone/src/config/docs.rs
+++ b/gemstone/src/config/docs.rs
@@ -21,6 +21,7 @@ pub enum DocsUrl {
     AccountMinimalBalance,
     TokenVerification,
     AddCustomToken,
+    WalletConnect
 }
 const DOCS_URL: &str = "https://docs.gemwallet.com";
 
@@ -47,6 +48,7 @@ pub fn get_docs_url(item: DocsUrl) -> String {
         DocsUrl::AccountMinimalBalance => "/faq/account-minimal-balance/",
         DocsUrl::TokenVerification => "/faq/token-verification/",
         DocsUrl::AddCustomToken => "/guides/add-token/",
+        DocsUrl::WalletConnect => "/guides/walletconnect/",
     };
     format!("{}{}", DOCS_URL, path)
 }


### PR DESCRIPTION
To resolve iOS issue: https://github.com/gemwalletcom/gem-ios/issues/733 a new docs URL needs to be added