### PR TITLE
Refactor transaction and receipt deserialization in tests

### DIFF
--- a/crates/gem_evm/src/rpc/swap_mapper.rs
+++ b/crates/gem_evm/src/rpc/swap_mapper.rs
@@ -217,17 +217,17 @@ impl SwapMapper {
 mod tests {
     use super::*;
     use crate::{rpc::swap_mapper::SwapMapper, uniswap::contracts::v3::Dispatcher};
-    use primitives::Chain;
+    use primitives::{Chain, JsonRpcResult};
 
     #[test]
     fn test_map_v4_swap_eth_dai() {
         let tx_json = include_str!("test/v4_eth_dai_tx.json");
-        let tx_value: serde_json::Value = serde_json::from_str(tx_json).unwrap();
-        let tx: Transaction = serde_json::from_value(tx_value.get("result").unwrap().clone()).unwrap();
+        let tx_value: JsonRpcResult<Transaction> = serde_json::from_str(tx_json).unwrap();
+        let tx = tx_value.result;
 
         let receipt_json = include_str!("test/v4_eth_dai_tx_receipt.json");
-        let receipt_value: serde_json::Value = serde_json::from_str(receipt_json).unwrap();
-        let receipt: TransactionReciept = serde_json::from_value(receipt_value.get("result").unwrap().clone()).unwrap();
+        let receipt_value: JsonRpcResult<TransactionReciept> = serde_json::from_str(receipt_json).unwrap();
+        let receipt = receipt_value.result;
 
         let swap_tx = SwapMapper::map_uniswap_transaction(&Chain::Unichain, &tx, &receipt, DateTime::default()).expect("swap_metadata");
         let metadata: TransactionSwapMetadata = serde_json::from_value(swap_tx.metadata.unwrap()).unwrap();
@@ -260,12 +260,12 @@ mod tests {
     #[test]
     fn test_map_v4_swap_usdc_eth() {
         let tx_json = include_str!("test/v4_usdc_eth_tx.json");
-        let tx_value: serde_json::Value = serde_json::from_str(tx_json).unwrap();
-        let tx: Transaction = serde_json::from_value(tx_value.get("result").unwrap().clone()).unwrap();
+        let tx_value: JsonRpcResult<Transaction> = serde_json::from_str(tx_json).unwrap();
+        let tx = tx_value.result;
 
         let receipt_json = include_str!("test/v4_usdc_eth_tx_receipt.json");
-        let receipt_value: serde_json::Value = serde_json::from_str(receipt_json).unwrap();
-        let receipt: TransactionReciept = serde_json::from_value(receipt_value.get("result").unwrap().clone()).unwrap();
+        let receipt_value: JsonRpcResult<TransactionReciept> = serde_json::from_str(receipt_json).unwrap();
+        let receipt = receipt_value.result;
 
         let swap_tx = SwapMapper::map_uniswap_transaction(&Chain::Unichain, &tx, &receipt, DateTime::default()).expect("swap_metadata");
         let metadata: TransactionSwapMetadata = serde_json::from_value(swap_tx.metadata.unwrap()).unwrap();
@@ -299,12 +299,12 @@ mod tests {
     fn test_map_v3_swap_eth_token() {
         // https://app.blocksec.com/explorer/tx/eth/0xfdbc3270b7edf1e63c0aaec9466a71348a1e63bdf069af2d51e9902f996e9d75
         let tx_json = include_str!("test/v3_eth_token_tx.json");
-        let tx_value: serde_json::Value = serde_json::from_str(tx_json).unwrap();
-        let tx: Transaction = serde_json::from_value(tx_value.get("result").unwrap().clone()).unwrap();
+        let tx_value: JsonRpcResult<Transaction> = serde_json::from_str(tx_json).unwrap();
+        let tx = tx_value.result;
 
         let receipt_json = include_str!("test/v3_eth_token_tx_receipt.json");
-        let receipt_value: serde_json::Value = serde_json::from_str(receipt_json).unwrap();
-        let receipt: TransactionReciept = serde_json::from_value(receipt_value.get("result").unwrap().clone()).unwrap();
+        let receipt_value: JsonRpcResult<TransactionReciept> = serde_json::from_str(receipt_json).unwrap();
+        let receipt = receipt_value.result;
 
         let swap_tx = SwapMapper::map_uniswap_transaction(&Chain::Ethereum, &tx, &receipt, DateTime::default()).expect("swap_metadata");
         let metadata: TransactionSwapMetadata = serde_json::from_value(swap_tx.metadata.unwrap()).unwrap();
@@ -338,12 +338,12 @@ mod tests {
     fn test_map_v3_swap_token_eth() {
         // https://app.blocksec.com/explorer/tx/base/0xc6c2898ddc2d2165bc6c018ec6ebf58d99922c74b9a0e323b50c029d10b09858
         let tx_json = include_str!("test/v3_token_eth_tx.json");
-        let tx_value: serde_json::Value = serde_json::from_str(tx_json).unwrap();
-        let tx: Transaction = serde_json::from_value(tx_value.get("result").unwrap().clone()).unwrap();
+        let tx_value: JsonRpcResult<Transaction> = serde_json::from_str(tx_json).unwrap();
+        let tx = tx_value.result;
 
         let receipt_json = include_str!("test/v3_token_eth_tx_receipt.json");
-        let receipt_value: serde_json::Value = serde_json::from_str(receipt_json).unwrap();
-        let receipt: TransactionReciept = serde_json::from_value(receipt_value.get("result").unwrap().clone()).unwrap();
+        let receipt_value: JsonRpcResult<TransactionReciept> = serde_json::from_str(receipt_json).unwrap();
+        let receipt = receipt_value.result;
 
         let swap_tx = SwapMapper::map_uniswap_transaction(&Chain::Base, &tx, &receipt, DateTime::default()).unwrap();
         let metadata: TransactionSwapMetadata = serde_json::from_value(swap_tx.metadata.unwrap()).unwrap();
@@ -377,12 +377,12 @@ mod tests {
     fn test_map_v3_swap_pol_usdt() {
         // https://app.blocksec.com/explorer/tx/polygon/0x815759e89e4290873109e482f1f3284cdaca3eb76ff24591a9ac2c6056a2dbcc
         let tx_json = include_str!("test/v3_pol_usdt_tx.json");
-        let tx_value: serde_json::Value = serde_json::from_str(tx_json).unwrap();
-        let tx: Transaction = serde_json::from_value(tx_value.get("result").unwrap().clone()).unwrap();
+        let tx_value: JsonRpcResult<Transaction> = serde_json::from_str(tx_json).unwrap();
+        let tx = tx_value.result;
 
         let receipt_json = include_str!("test/v3_pol_usdt_tx_receipt.json");
-        let receipt_value: serde_json::Value = serde_json::from_str(receipt_json).unwrap();
-        let receipt: TransactionReciept = serde_json::from_value(receipt_value.get("result").unwrap().clone()).unwrap();
+        let receipt_value: JsonRpcResult<TransactionReciept> = serde_json::from_str(receipt_json).unwrap();
+        let receipt = receipt_value.result;
 
         let swap_tx = SwapMapper::map_uniswap_transaction(&Chain::Polygon, &tx, &receipt, DateTime::default()).expect("swap_metadata");
         let metadata: TransactionSwapMetadata = serde_json::from_value(swap_tx.metadata.unwrap()).unwrap();
@@ -416,12 +416,12 @@ mod tests {
     fn test_map_v3_swap_usdc_paxg() {
         // https://app.blocksec.com/explorer/tx/eth/0x65b5ff389386caf23a9998318d936e434c5bbca850877f1ca03eb246b3ad82e1
         let tx_json = include_str!("test/v3_usdc_paxg_tx.json");
-        let tx_value: serde_json::Value = serde_json::from_str(tx_json).unwrap();
-        let tx: Transaction = serde_json::from_value(tx_value.get("result").unwrap().clone()).unwrap();
+        let tx_value: JsonRpcResult<Transaction> = serde_json::from_str(tx_json).unwrap();
+        let tx = tx_value.result;
 
         let receipt_json = include_str!("test/v3_usdc_paxg_receipt.json");
-        let receipt_value: serde_json::Value = serde_json::from_str(receipt_json).unwrap();
-        let receipt: TransactionReciept = serde_json::from_value(receipt_value.get("result").unwrap().clone()).unwrap();
+        let receipt_value: JsonRpcResult<TransactionReciept> = serde_json::from_str(receipt_json).unwrap();
+        let receipt = receipt_value.result;
 
         let swap_tx = SwapMapper::map_uniswap_transaction(&Chain::Ethereum, &tx, &receipt, DateTime::default()).expect("swap_metadata");
         let metadata: TransactionSwapMetadata = serde_json::from_value(swap_tx.metadata.unwrap()).unwrap();


### PR DESCRIPTION
Updated test cases in mapper.rs and swap_mapper.rs to deserialize Transaction and TransactionReciept using the JsonRpcResult wrapper instead of manual extraction from serde_json::Value. Also improved native transfer detection and smart contract call logic in EthereumMapper, and added a helper for data cost calculation.