### PR TITLE
Add creationType for wallet

### DIFF
--- a/crates/primitives/src/wallet.rs
+++ b/crates/primitives/src/wallet.rs
@@ -11,6 +11,8 @@ struct Wallet {
     is_pinned: bool,
     #[serde(rename = "imageUrl")]
     image_url: Option<String>,
+    #[serde(rename = "creationType")]
+    creation_type: WalletCreationType,
 }
 
 #[typeshare(swift = "Equatable, Hashable, Sendable")]
@@ -20,6 +22,12 @@ pub enum WalletType {
     single,
     private_key,
     view,
+}
+
+#[typeshare(swift = "Equatable, Hashable, Sendable")]
+pub enum WalletCreationType {
+    imported,
+    created,
 }
 
 #[typeshare(swift = "Equatable, Sendable")]


### PR DESCRIPTION
To reducing load on the core, implemented creationType. This allows passing a parameter when a new wallet is created.
Also needs for PR: https://github.com/gemwalletcom/gem-ios/pull/851