### PR TITLE
feat: Add send max support flag to chain configuration

### DIFF
--- a/crates/primitives/src/chain.rs
+++ b/crates/primitives/src/chain.rs
@@ -465,4 +465,8 @@ impl Chain {
     pub fn stakeable() -> Vec<Self> {
         Self::all().into_iter().filter(|x| x.is_stake_supported()).collect()
     }
+
+    pub fn is_send_max_supported(&self) -> bool {
+        !matches!(self, Self::Solana)
+    }
 }

--- a/gemstone/src/chain/mod.rs
+++ b/gemstone/src/chain/mod.rs
@@ -19,6 +19,7 @@ pub struct ChainConfig {
     pub is_stake_supported: bool,
     pub is_nft_supported: bool,
     pub is_memo_supported: bool,
+    pub is_send_max_supported: bool,
 }
 
 pub fn get_chain_config(chain: Chain) -> ChainConfig {
@@ -40,6 +41,7 @@ pub fn get_chain_config(chain: Chain) -> ChainConfig {
         is_stake_supported: chain.is_stake_supported(),
         is_nft_supported: chain.is_nft_supported(),
         is_memo_supported: is_memo_supported(chain),
+        is_send_max_supported: chain.is_send_max_supported(),
     }
 }
 


### PR DESCRIPTION
Add `is_send_max_supported` flag to ChainConfig to indicate whether a chain supports sending maximum balance. The flag returns false for Solana (due to rent-exempt balance requirements) and true for all other chains.

- Add `is_send_max_supported()` method to Chain enum
- Add `is_send_max_supported` field to ChainConfig struct
- Update Swift bindings to expose the flag in iOS app

🤖 Generated with [Claude Code](https://claude.ai/code)