### PR TITLE
Add SuspiciousAsset case to BannerEvent enum

### DIFF
--- a/crates/primitives/src/banner.rs
+++ b/crates/primitives/src/banner.rs
@@ -16,6 +16,7 @@ pub enum BannerEvent {
     EnableNotifications,
     AccountBlockedMultiSignature,
     ActivateAsset,
+    SuspiciousAsset,
 }
 
 #[typeshare(swift = "Equatable, CaseIterable, Sendable")]


### PR DESCRIPTION
Extends the BannerEvent enum to support warning banners for suspicious assets, allowing the iOS app to display appropriate warnings when users interact with potentially risky tokens.

🤖 Generated with [Claude Code](https://claude.ai/code)