### PR TITLE
Add PerpetualConfig to gemstone

### DIFF
--- a/gemstone/src/config/mod.rs
+++ b/gemstone/src/config/mod.rs
@@ -2,6 +2,7 @@ pub mod bitcoin_chain;
 pub mod docs;
 pub mod evm_chain;
 pub mod node;
+pub mod perpetual_config;
 pub mod public;
 pub mod social;
 pub mod stake;
@@ -20,6 +21,7 @@ use {
     bitcoin_chain::{get_bitcoin_chain_config, BitcoinChainConfig},
     docs::{get_docs_url, DocsUrl},
     evm_chain::{get_evm_chain_config, EVMChainConfig},
+    perpetual_config::{get_perpetual_config, PerpetualConfig},
     public::{get_public_url, PublicUrl, ASSETS_URL},
     social::{get_social_url, get_social_url_deeplink, SocialUrl},
     stake::{get_stake_config, StakeChainConfig},
@@ -49,6 +51,10 @@ impl Config {
 
     fn get_swap_config(&self) -> SwapConfig {
         get_swap_config()
+    }
+
+    fn get_perpetual_config(&self) -> PerpetualConfig {
+        get_perpetual_config()
     }
 
     fn get_docs_url(&self, item: DocsUrl) -> String {

--- a/gemstone/src/config/perpetual_config.rs
+++ b/gemstone/src/config/perpetual_config.rs
@@ -1,5 +1,3 @@
-pub static DEFAULT_MAX_BUILDER_FEE_BPS: u32 = 45; // 0.045%
-
 #[derive(uniffi::Record, Debug, Clone, PartialEq)]
 pub struct PerpetualConfig {
     pub builder_address: String,
@@ -11,6 +9,6 @@ pub fn get_perpetual_config() -> PerpetualConfig {
     PerpetualConfig {
         builder_address: "0x0d9dab1a248f63b0a48965ba8435e4de7497a3dc".into(),
         referral_code: "GEMWALLET".into(),
-        max_builder_fee_bps: DEFAULT_MAX_BUILDER_FEE_BPS,
+        max_builder_fee_bps: 45,
     }
 }

--- a/gemstone/src/config/perpetual_config.rs
+++ b/gemstone/src/config/perpetual_config.rs
@@ -1,36 +1,16 @@
-pub static DEFAULT_MAX_LEVERAGE: u32 = 10;
-pub static DEFAULT_FEE_BPS: u32 = 10; // 0.1%
-pub static DEFAULT_MIN_POSITION_SIZE_USD: u64 = 10;
 pub static DEFAULT_MAX_BUILDER_FEE_BPS: u32 = 45; // 0.045%
 
 #[derive(uniffi::Record, Debug, Clone, PartialEq)]
 pub struct PerpetualConfig {
-    pub default_max_leverage: u32,
-    pub fee_bps: u32,
-    pub min_position_size_usd: u64,
     pub builder_address: String,
     pub referral_code: String,
     pub max_builder_fee_bps: u32,
-    pub referral_fee: PerpetualReferralFee,
-}
-
-#[derive(uniffi::Record, Default, Debug, Clone, PartialEq)]
-pub struct PerpetualReferralFee {
-    pub address: String,
-    pub bps: u32,
 }
 
 pub fn get_perpetual_config() -> PerpetualConfig {
     PerpetualConfig {
-        default_max_leverage: DEFAULT_MAX_LEVERAGE,
-        fee_bps: DEFAULT_FEE_BPS,
-        min_position_size_usd: DEFAULT_MIN_POSITION_SIZE_USD,
         builder_address: "0x0d9dab1a248f63b0a48965ba8435e4de7497a3dc".into(),
         referral_code: "GEMWALLET".into(),
         max_builder_fee_bps: DEFAULT_MAX_BUILDER_FEE_BPS,
-        referral_fee: PerpetualReferralFee {
-            address: "0x0D9DAB1A248f63B0a48965bA8435e4de7497a3dC".into(),
-            bps: DEFAULT_FEE_BPS,
-        },
     }
 }

--- a/gemstone/src/config/perpetual_config.rs
+++ b/gemstone/src/config/perpetual_config.rs
@@ -1,5 +1,3 @@
-pub static DEFAULT_MAX_BUILDER_FEE_BPS: u32 = 45; // 0.045%
-
 #[derive(uniffi::Record, Debug, Clone, PartialEq)]
 pub struct PerpetualConfig {
     pub builder_address: String,
@@ -11,6 +9,6 @@ pub fn get_perpetual_config() -> PerpetualConfig {
     PerpetualConfig {
         builder_address: "0x0d9dab1a248f63b0a48965ba8435e4de7497a3dc".into(),
         referral_code: "GEMWALLET".into(),
-        max_builder_fee_bps: DEFAULT_MAX_BUILDER_FEE_BPS,
+        max_builder_fee_bps: 45, // 0.045%
     }
 }

--- a/gemstone/src/config/perpetual_config.rs
+++ b/gemstone/src/config/perpetual_config.rs
@@ -1,3 +1,5 @@
+pub static DEFAULT_MAX_BUILDER_FEE_BPS: u32 = 45; // 0.045%
+
 #[derive(uniffi::Record, Debug, Clone, PartialEq)]
 pub struct PerpetualConfig {
     pub builder_address: String,
@@ -9,6 +11,6 @@ pub fn get_perpetual_config() -> PerpetualConfig {
     PerpetualConfig {
         builder_address: "0x0d9dab1a248f63b0a48965ba8435e4de7497a3dc".into(),
         referral_code: "GEMWALLET".into(),
-        max_builder_fee_bps: 45, // 0.045%
+        max_builder_fee_bps: DEFAULT_MAX_BUILDER_FEE_BPS,
     }
 }

--- a/gemstone/src/config/perpetual_config.rs
+++ b/gemstone/src/config/perpetual_config.rs
@@ -1,0 +1,36 @@
+pub static DEFAULT_MAX_LEVERAGE: u32 = 10;
+pub static DEFAULT_FEE_BPS: u32 = 10; // 0.1%
+pub static DEFAULT_MIN_POSITION_SIZE_USD: u64 = 10;
+pub static DEFAULT_MAX_BUILDER_FEE_BPS: u32 = 45; // 0.045%
+
+#[derive(uniffi::Record, Debug, Clone, PartialEq)]
+pub struct PerpetualConfig {
+    pub default_max_leverage: u32,
+    pub fee_bps: u32,
+    pub min_position_size_usd: u64,
+    pub builder_address: String,
+    pub referral_code: String,
+    pub max_builder_fee_bps: u32,
+    pub referral_fee: PerpetualReferralFee,
+}
+
+#[derive(uniffi::Record, Default, Debug, Clone, PartialEq)]
+pub struct PerpetualReferralFee {
+    pub address: String,
+    pub bps: u32,
+}
+
+pub fn get_perpetual_config() -> PerpetualConfig {
+    PerpetualConfig {
+        default_max_leverage: DEFAULT_MAX_LEVERAGE,
+        fee_bps: DEFAULT_FEE_BPS,
+        min_position_size_usd: DEFAULT_MIN_POSITION_SIZE_USD,
+        builder_address: "0x0d9dab1a248f63b0a48965ba8435e4de7497a3dc".into(),
+        referral_code: "GEMWALLET".into(),
+        max_builder_fee_bps: DEFAULT_MAX_BUILDER_FEE_BPS,
+        referral_fee: PerpetualReferralFee {
+            address: "0x0D9DAB1A248f63B0a48965bA8435e4de7497a3dC".into(),
+            bps: DEFAULT_FEE_BPS,
+        },
+    }
+}


### PR DESCRIPTION
## Summary
Adds PerpetualConfig to gemstone following the same pattern as SwapConfig, but simplified to only include HyperCore-specific configuration.

## Changes
- Created `PerpetualConfig` struct in `gemstone/src/config/perpetual_config.rs` with:
  - `builder_address`: 0x0d9dab1a248f63b0a48965ba8435e4de7497a3dc
  - `referral_code`: GEMWALLET
  - `max_builder_fee_bps`: 45 (0.045%)

- Added module to `config/mod.rs` and exposed via `get_perpetual_config()` method

## Context
This is needed for iOS issue gemwalletcom/gem-ios#1081 to move hardcoded HyperCore configuration values to a centralized config.

## Test Plan
- [x] Build core successfully
- [x] Generate bindings for iOS
- [x] Test with iOS implementation

🤖 Generated with [Claude Code](https://claude.ai/code)