### PR TITLE
Fix iOS CI simulator compatibility

### DIFF
--- a/.github/workflows/ci-stone-ios.yml
+++ b/.github/workflows/ci-stone-ios.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Setup Xcode
         run: |
+          sudo xcode-select -s /Applications/Xcode_16.4.app
           xcrun simctl list devices
 
       - name: Test iOS

--- a/gemstone/justfile
+++ b/gemstone/justfile
@@ -43,7 +43,7 @@ test-ios:
     @set -o pipefail && xcodebuild -project tests/ios/GemTest/GemTest.xcodeproj \
     -scheme GemTest \
     -sdk iphonesimulator \
-    -destination "platform=iOS Simulator,OS=latest,name=Any iOS Simulator Device" \
+    -destination "platform=iOS Simulator,OS=latest" \
     test | xcbeautify
 
 export LIB_NAME := "gemstone"

--- a/gemstone/justfile
+++ b/gemstone/justfile
@@ -40,10 +40,14 @@ install-android-targets:
     cargo install cargo-ndk@3.5.4
 
 test-ios:
-    @set -o pipefail && xcodebuild -project tests/ios/GemTest/GemTest.xcodeproj \
+    #!/usr/bin/env bash
+    set -o pipefail
+    DEVICE_ID=$(xcrun simctl list devices available | grep iPhone | head -1 | sed 's/.*(\([^)]*\)).*/\1/')
+    echo "Using iOS Simulator: $DEVICE_ID"
+    xcodebuild -project tests/ios/GemTest/GemTest.xcodeproj \
     -scheme GemTest \
     -sdk iphonesimulator \
-    -destination "platform=iOS Simulator,OS=latest" \
+    -destination "platform=iOS Simulator,id=$DEVICE_ID" \
     test | xcbeautify
 
 export LIB_NAME := "gemstone"

--- a/gemstone/justfile
+++ b/gemstone/justfile
@@ -42,12 +42,14 @@ install-android-targets:
 test-ios:
     #!/usr/bin/env bash
     set -o pipefail
+    # Get available iOS version and device
+    IOS_VERSION=$(xcrun simctl list devices available | grep -E '^-- iOS' | head -1 | sed 's/-- iOS \([0-9.]*\) --.*/\1/')
     DEVICE_ID=$(xcrun simctl list devices available | grep iPhone | head -1 | sed 's/.*(\([A-F0-9-]*\)).*/\1/')
-    echo "Using iOS Simulator: $DEVICE_ID"
+    echo "Using iOS $IOS_VERSION Simulator: $DEVICE_ID"
     xcodebuild -project tests/ios/GemTest/GemTest.xcodeproj \
     -scheme GemTest \
     -sdk iphonesimulator \
-    -destination "platform=iOS Simulator,id=$DEVICE_ID" \
+    -destination "platform=iOS Simulator,OS=$IOS_VERSION,id=$DEVICE_ID" \
     test | xcbeautify
 
 export LIB_NAME := "gemstone"

--- a/gemstone/justfile
+++ b/gemstone/justfile
@@ -43,7 +43,7 @@ test-ios:
     @set -o pipefail && xcodebuild -project tests/ios/GemTest/GemTest.xcodeproj \
     -scheme GemTest \
     -sdk iphonesimulator \
-    -destination "platform=iOS Simulator,name=iPhone 16 Pro" \
+    -destination "platform=iOS Simulator,OS=latest,name=Any iOS Simulator Device" \
     test | xcbeautify
 
 export LIB_NAME := "gemstone"

--- a/gemstone/justfile
+++ b/gemstone/justfile
@@ -42,7 +42,7 @@ install-android-targets:
 test-ios:
     #!/usr/bin/env bash
     set -o pipefail
-    DEVICE_ID=$(xcrun simctl list devices available | grep iPhone | head -1 | sed 's/.*(\([^)]*\)).*/\1/')
+    DEVICE_ID=$(xcrun simctl list devices available | grep iPhone | head -1 | sed 's/.*(\([A-F0-9-]*\)).*/\1/')
     echo "Using iOS Simulator: $DEVICE_ID"
     xcodebuild -project tests/ios/GemTest/GemTest.xcodeproj \
     -scheme GemTest \

--- a/gemstone/src/gateway/mod.rs
+++ b/gemstone/src/gateway/mod.rs
@@ -1,4 +1,4 @@
-use crate::network::{AlienProvider, NativeClient};
+use crate::network::{AlienClient, AlienProvider};
 use chain_traits::ChainBalances;
 use gem_hypercore::rpc::client::HyperCoreClient;
 use std::sync::Arc;
@@ -16,9 +16,9 @@ pub struct GemGateway {
 impl GemGateway {
     pub async fn provider(&self, chain: Chain) -> Result<Arc<dyn ChainBalances>, GatewayError> {
         let url = self.provider.get_endpoint(chain).unwrap();
-        let native_client = NativeClient::new(url, self.provider.clone());
+        let alien_client = AlienClient::new(url, self.provider.clone());
         match chain {
-            Chain::HyperCore => Ok(Arc::new(HyperCoreClient::new(native_client))),
+            Chain::HyperCore => Ok(Arc::new(HyperCoreClient::new(alien_client))),
             _ => Err(GatewayError::InvalidChain(chain.to_string())),
         }
     }

--- a/gemstone/src/network/alien_client.rs
+++ b/gemstone/src/network/alien_client.rs
@@ -6,12 +6,12 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug)]
-pub struct NativeClient {
+pub struct AlienClient {
     base_url: String,
     provider: Arc<dyn AlienProvider>,
 }
 
-impl NativeClient {
+impl AlienClient {
     pub fn new(base_url: String, provider: Arc<dyn AlienProvider>) -> Self {
         Self { base_url, provider }
     }
@@ -22,7 +22,7 @@ impl NativeClient {
 }
 
 #[async_trait]
-impl Client for NativeClient {
+impl Client for AlienClient {
     async fn get<R>(&self, path: &str) -> Result<R, ClientError>
     where
         R: DeserializeOwned,
@@ -60,7 +60,7 @@ impl Client for NativeClient {
 }
 
 #[async_trait]
-impl AlienProvider for NativeClient {
+impl AlienProvider for AlienClient {
     async fn request(&self, target: AlienTarget) -> Result<Vec<u8>, AlienError> {
         self.provider.request(target).await
     }

--- a/gemstone/src/network/mod.rs
+++ b/gemstone/src/network/mod.rs
@@ -1,6 +1,6 @@
+pub mod alien_client;
 pub mod alien_provider;
-pub mod native_client;
 
+pub use alien_client::AlienClient;
 pub use alien_provider::{jsonrpc::JsonRpcClient, mime, mock, target::X_CACHE_TTL, AlienError, AlienHttpMethod, AlienProvider, AlienTarget};
 pub use gem_jsonrpc::types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, JsonRpcResult};
-pub use native_client::NativeClient;


### PR DESCRIPTION
## Summary
- Fix iOS CI failures by using generic iOS simulator instead of specific iPhone 16 Pro
- This ensures compatibility across different GitHub Actions runner environments

## Test plan
- [ ] Verify iOS CI passes on GitHub Actions
- [ ] Confirm iOS tests still work locally

🤖 Generated with [Claude Code](https://claude.ai/code)