### PR TITLE
Refactor to remove reqwest-middleware and use gem_client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,10 +1632,10 @@ name = "coingecko"
 version = "1.0.0"
 dependencies = [
  "chrono",
+ "gem_client",
  "lazy_static",
  "primitives",
  "reqwest",
- "reqwest-middleware",
  "serde",
 ]
 
@@ -2976,7 +2976,6 @@ dependencies = [
  "number_formatter",
  "primitives",
  "reqwest",
- "reqwest-middleware",
  "serde",
  "serde_json",
  "serde_serializers",
@@ -3045,7 +3044,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "primitives",
- "reqwest-middleware",
  "serde",
  "serde_json",
  "serde_serializers",
@@ -5767,21 +5765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-middleware"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 1.3.1",
- "reqwest",
- "serde",
- "thiserror 1.0.69",
- "tower-service",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6618,7 +6601,6 @@ dependencies = [
  "gem_xrp",
  "primitives",
  "reqwest",
- "reqwest-middleware",
  "settings",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,6 +2991,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "thiserror 2.0.16",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ serde_json = { version = "1.0.143", features = ["preserve_order"] }
 serde_urlencoded = { version = "0.7.1" }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 reqwest = { version = "0.12.23", features = ["json"] }
-reqwest-middleware = { version = "0.4.2" }
 reqwest-enum = { version = "0.4.0", features = ["jsonrpc"] }
 idna = "1.1.0"
 url = { version = "2.5.6" }

--- a/apps/daemon/src/pricer/mod.rs
+++ b/apps/daemon/src/pricer/mod.rs
@@ -198,17 +198,17 @@ pub async fn jobs(settings: Settings) -> Vec<Pin<Box<dyn Future<Output = ()> + S
 fn price_updater_factory(cacher: &CacherClient, settings: &Settings) -> PriceUpdater {
     let coingecko_client = CoinGeckoClient::new(&settings.coingecko.key.secret.clone());
     let price_client = PriceClient::new(cacher.clone(), &settings.postgres.url.clone());
-    PriceUpdater::new(price_client, coingecko_client.clone())
+    PriceUpdater::new(price_client, coingecko_client)
 }
 
 fn price_asset_updater_factory(cacher: &CacherClient, settings: &Settings) -> PriceAssetUpdater {
     let coingecko_client = CoinGeckoClient::new(&settings.coingecko.key.secret.clone());
     let price_client = PriceClient::new(cacher.clone(), &settings.postgres.url.clone());
-    PriceAssetUpdater::new(price_client, coingecko_client.clone())
+    PriceAssetUpdater::new(price_client, coingecko_client)
 }
 
 fn markets_updater_factory(cacher: &CacherClient, settings: &Settings) -> MarketsUpdater {
     let coingecko_client = CoinGeckoClient::new(&settings.coingecko.key.secret.clone());
     let markets_client = MarketsClient::new(&settings.postgres.url.clone(), cacher.clone());
-    MarketsUpdater::new(markets_client, coingecko_client.clone())
+    MarketsUpdater::new(markets_client, coingecko_client)
 }

--- a/bin/img-downloader/src/main.rs
+++ b/bin/img-downloader/src/main.rs
@@ -2,8 +2,7 @@ mod cli_args;
 use cli_args::Args;
 
 use coingecko::get_chain_for_coingecko_platform_id;
-use coingecko::{CoinGeckoClient, CoinInfo, COINGECKO_API_HOST};
-use gem_client::retry::retry_policy;
+use coingecko::{CoinGeckoClient, CoinInfo};
 use settings::Settings;
 
 use clap::Parser;
@@ -23,9 +22,7 @@ impl Downloader {
     }
 
     fn new_coingecko_client(api_key: String) -> CoinGeckoClient {
-        let retry_policy = retry_policy(COINGECKO_API_HOST, 10);
-        let reqwest_client = reqwest::Client::builder().retry(retry_policy).build().expect("Failed to build reqwest client");
-        CoinGeckoClient::new_with_reqwest_client(reqwest_client, api_key.as_str())
+        CoinGeckoClient::new(api_key.as_str())
     }
 
     async fn start(&self) -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/crates/coingecko/Cargo.toml
+++ b/crates/coingecko/Cargo.toml
@@ -5,8 +5,8 @@ version = { workspace = true }
 
 [dependencies]
 serde = { workspace = true }
-reqwest = { workspace = true }
 primitives = { path = "../primitives" }
 chrono = { workspace = true }
 lazy_static = { workspace = true }
-reqwest-middleware = { workspace = true }
+gem_client = { path = "../gem_client", features = ["reqwest"] }
+reqwest = { workspace = true }

--- a/crates/coingecko/src/lib.rs
+++ b/crates/coingecko/src/lib.rs
@@ -2,6 +2,9 @@ pub mod client;
 pub mod mapper;
 pub mod model;
 
-pub use self::client::{CoinGeckoClient, COINGECKO_API_HOST, COINGECKO_API_PRO_HOST};
+pub use self::client::{COINGECKO_API_HOST, COINGECKO_API_PRO_HOST};
 pub use self::mapper::{get_chain_for_coingecko_platform_id, get_coingecko_market_id_for_chain};
 pub use self::model::{Coin, CoinInfo, CoinMarket};
+
+use gem_client::ReqwestClient;
+pub type CoinGeckoClient = client::CoinGeckoClient<ReqwestClient>;

--- a/crates/coingecko/src/lib.rs
+++ b/crates/coingecko/src/lib.rs
@@ -4,7 +4,7 @@ pub mod model;
 
 pub use self::client::{COINGECKO_API_HOST, COINGECKO_API_PRO_HOST};
 pub use self::mapper::{get_chain_for_coingecko_platform_id, get_coingecko_market_id_for_chain};
-pub use self::model::{Coin, CoinInfo, CoinMarket};
+pub use self::model::{Coin, CoinInfo, CoinMarket, CoinGeckoErrorResponse, CoinGeckoResponse};
 
 use gem_client::ReqwestClient;
 pub type CoinGeckoClient = client::CoinGeckoClient<ReqwestClient>;

--- a/crates/coingecko/src/model.rs
+++ b/crates/coingecko/src/model.rs
@@ -178,3 +178,15 @@ impl CoinIds {
         self.0.iter().map(|x| x.id.clone()).collect()
     }
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CoinGeckoErrorResponse {
+    pub error: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum CoinGeckoResponse<T> {
+    Success(T),
+    Error(CoinGeckoErrorResponse),
+}

--- a/crates/gem_algorand/src/rpc/client.rs
+++ b/crates/gem_algorand/src/rpc/client.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::error::Error;
 
 use crate::models::{Account, AssetDetails, TransactionBroadcast, TransactionStatus, TransactionsParams};
-use gem_client::ContentType;
+use gem_client::{ContentType, CONTENT_TYPE};
 
 #[cfg(feature = "rpc")]
 use chain_traits::{ChainAccount, ChainPerpetual, ChainProvider, ChainStaking, ChainTraits};
@@ -43,7 +43,7 @@ impl<C: Client> AlgorandClient<C> {
 
     pub async fn broadcast_transaction(&self, data: &str) -> Result<TransactionBroadcast, Box<dyn Error + Send + Sync>> {
         let headers = Some(HashMap::from([(
-            "Content-Type".to_string(),
+            CONTENT_TYPE.to_string(),
             ContentType::ApplicationXBinary.as_str().to_string(),
         )]));
 

--- a/crates/gem_bitcoin/src/rpc/client.rs
+++ b/crates/gem_bitcoin/src/rpc/client.rs
@@ -5,7 +5,7 @@ use crate::models::block::{BitcoinBlock, BitcoinNodeInfo, Block, Status};
 use crate::models::fee::BitcoinFeeResult;
 use crate::models::transaction::{AddressDetails, BitcoinTransactionBroacastResult, BitcoinUTXO, Transaction};
 use chain_traits::{ChainPerpetual, ChainStaking, ChainToken, ChainTraits};
-use gem_client::{Client, ContentType};
+use gem_client::{Client, ContentType, CONTENT_TYPE};
 use primitives::{chain::Chain, BitcoinChain};
 use std::collections::HashMap;
 
@@ -53,7 +53,7 @@ impl<C: Client> BitcoinClient<C> {
     }
 
     pub async fn broadcast_transaction(&self, data: String) -> Result<BitcoinTransactionBroacastResult, Box<dyn Error + Send + Sync>> {
-        let headers = Some(HashMap::from([("Content-Type".to_string(), ContentType::TextPlain.as_str().to_string())]));
+        let headers = Some(HashMap::from([(CONTENT_TYPE.to_string(), ContentType::TextPlain.as_str().to_string())]));
         Ok(self.client.post("/api/v2/sendtx/", &data, headers).await?)
     }
 

--- a/crates/gem_chain_rpc/Cargo.toml
+++ b/crates/gem_chain_rpc/Cargo.toml
@@ -43,7 +43,6 @@ num-bigint = { workspace = true }
 [dev-dependencies]
 tokio.workspace = true
 reqwest.workspace = true
-reqwest-middleware.workspace = true
 gem_jsonrpc = { path = "../gem_jsonrpc" }
 
 [[test]]

--- a/crates/gem_chain_rpc/src/ethereum.rs
+++ b/crates/gem_chain_rpc/src/ethereum.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::hex;
 use alloy_sol_types::SolCall;
 use async_trait::async_trait;
+use gem_client::Client;
 use num_bigint::BigUint;
 use std::error::Error;
 
@@ -127,7 +128,7 @@ impl ChainStakeProvider for EthereumProvider {
 // AlchemyClient
 
 #[async_trait]
-impl ChainAssetsProvider for AlchemyClient {
+impl<C: Client> ChainAssetsProvider for AlchemyClient<C> {
     async fn get_assets_balances(&self, address: String) -> Result<Vec<AssetBalance>, Box<dyn Error + Send + Sync>> {
         let response = self.get_token_balances(&address).await?;
         let balances = response
@@ -146,7 +147,7 @@ impl ChainAssetsProvider for AlchemyClient {
 }
 
 #[async_trait]
-impl ChainTransactionsProvider for AlchemyClient {
+impl<C: Client> ChainTransactionsProvider for AlchemyClient<C> {
     async fn get_transactions_by_address(&self, address: String) -> Result<Vec<Transaction>, Box<dyn Error + Send + Sync>> {
         Ok(self.get_transactions_by_address(address.as_str()).await?)
     }

--- a/crates/gem_client/Cargo.toml
+++ b/crates/gem_client/Cargo.toml
@@ -12,5 +12,6 @@ async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+serde_urlencoded = { workspace = true }
 reqwest = { workspace = true, optional = true }
 hex = { workspace = true }

--- a/crates/gem_client/src/content_type.rs
+++ b/crates/gem_client/src/content_type.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+pub const CONTENT_TYPE: &str = "Content-Type";
 const APPLICATION_JSON: &str = "application/json";
 const TEXT_PLAIN: &str = "text/plain";
 const APPLICATION_FORM_URL_ENCODED: &str = "application/x-www-form-urlencoded";

--- a/crates/gem_client/src/lib.rs
+++ b/crates/gem_client/src/lib.rs
@@ -7,7 +7,10 @@ mod reqwest_client;
 #[cfg(feature = "reqwest")]
 pub mod retry;
 
-pub use content_type::ContentType;
+pub mod query;
+
+pub use content_type::{ContentType, CONTENT_TYPE};
+pub use query::build_path_with_query;
 pub use types::ClientError;
 
 #[cfg(feature = "reqwest")]

--- a/crates/gem_client/src/query.rs
+++ b/crates/gem_client/src/query.rs
@@ -1,0 +1,39 @@
+use serde::Serialize;
+
+/// Build a path with query parameters from a serializable struct
+pub fn build_path_with_query<T: Serialize>(path: &str, query: &T) -> Result<String, serde_urlencoded::ser::Error> {
+    let query_string = serde_urlencoded::to_string(query)?;
+    Ok(format!("{}?{}", path, query_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct CoinQuery {
+        pub market_data: bool,
+        pub community_data: bool,
+        pub tickers: bool,
+        pub localization: bool,
+        pub developer_data: bool,
+    }
+
+    #[test]
+    fn test_build_path_with_query_coingecko_case() {
+        let id = "bitcoin";
+        let query = CoinQuery {
+            market_data: false,
+            community_data: true,
+            tickers: false,
+            localization: true,
+            developer_data: true,
+        };
+        let base_path = format!("/api/v3/coins/{}", id);
+        let result = build_path_with_query(&base_path, &query).unwrap();
+
+        let expected = "/api/v3/coins/bitcoin?market_data=false&community_data=true&tickers=false&localization=true&developer_data=true";
+        assert_eq!(result, expected);
+    }
+}

--- a/crates/gem_client/src/reqwest_client.rs
+++ b/crates/gem_client/src/reqwest_client.rs
@@ -1,4 +1,4 @@
-use crate::{Client, ClientError, ContentType};
+use crate::{Client, ClientError, ContentType, CONTENT_TYPE};
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{collections::HashMap, str::FromStr};
@@ -68,9 +68,9 @@ impl Client for ReqwestClient {
         R: DeserializeOwned,
     {
         let url = self.build_url(path);
-        let headers = headers.unwrap_or_else(|| HashMap::from([("Content-Type".to_string(), ContentType::ApplicationJson.as_str().to_string())]));
+        let headers = headers.unwrap_or_else(|| HashMap::from([(CONTENT_TYPE.to_string(), ContentType::ApplicationJson.as_str().to_string())]));
 
-        let content_type = headers.get("Content-Type").and_then(|s| ContentType::from_str(s).ok());
+        let content_type = headers.get(CONTENT_TYPE).and_then(|s| ContentType::from_str(s).ok());
 
         let request_body = match content_type {
             Some(ContentType::TextPlain) | Some(ContentType::ApplicationFormUrlEncoded) | Some(ContentType::ApplicationXBinary) => {

--- a/crates/gem_evm/Cargo.toml
+++ b/crates/gem_evm/Cargo.toml
@@ -13,7 +13,7 @@ rpc = [
     "dep:lazy_static",
     "dep:itertools",
 ]
-reqwest = ["gem_jsonrpc/reqwest", "dep:reqwest-middleware"]
+reqwest = ["gem_jsonrpc/reqwest", "gem_client/reqwest"]
 
 [dependencies]
 primitives = { path = "../primitives" }
@@ -24,7 +24,6 @@ gem_jsonrpc = { path = "../gem_jsonrpc" }
 gem_client = { path = "../gem_client" }
 gem_bsc = { path = "../gem_bsc" }
 
-reqwest-middleware = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 hex = { workspace = true }
 itoa = { workspace = true }

--- a/crates/gem_evm/src/rpc/alchemy/client.rs
+++ b/crates/gem_evm/src/rpc/alchemy/client.rs
@@ -10,9 +10,9 @@ use crate::{
         EthereumClient, EthereumMapper,
     },
 };
-use primitives::EVMChain;
 #[cfg(feature = "reqwest")]
 use gem_client::Client;
+use primitives::EVMChain;
 use serde_json::json;
 
 use crate::rpc::alchemy::TokenBalances;
@@ -30,6 +30,12 @@ pub struct AlchemyClient<C: Client> {
 impl<C: Client> AlchemyClient<C> {
     const DISABLED_RPC_CHAINS: [EVMChain; 5] = [EVMChain::Mantle, EVMChain::Hyperliquid, EVMChain::OpBNB, EVMChain::Monad, EVMChain::Fantom];
     const ENABLED_TRANSACTION_CHAINS: [EVMChain; 2] = [EVMChain::Ethereum, EVMChain::Base];
+
+    fn common_headers() -> std::collections::HashMap<String, String> {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("Content-Type".to_string(), "application/json".to_string());
+        headers
+    }
 
     pub fn new(ethereum_client: EthereumClient, client: C, api_key: String) -> Self {
         let chain = ethereum_client.chain;
@@ -86,9 +92,7 @@ impl<C: Client> AlchemyClient<C> {
             ],
             "includeNativeTokens": false,
         });
-        let mut headers = std::collections::HashMap::new();
-        headers.insert("Content-Type".to_string(), "application/json".to_string());
-        Ok(self.client.post(&url, &payload, Some(headers)).await?)
+        Ok(self.client.post(&url, &payload, Some(Self::common_headers())).await?)
     }
     // https://www.alchemy.com/docs/data/portfolio-apis/portfolio-api-endpoints/portfolio-api-endpoints/get-transaction-history-by-address
     //TODO:
@@ -109,8 +113,6 @@ impl<C: Client> AlchemyClient<C> {
             ],
             "limit": 25,
         });
-        let mut headers = std::collections::HashMap::new();
-        headers.insert("Content-Type".to_string(), "application/json".to_string());
-        Ok(self.client.post(&url, &payload, Some(headers)).await?)
+        Ok(self.client.post(&url, &payload, Some(Self::common_headers())).await?)
     }
 }

--- a/crates/gem_evm/src/rpc/alchemy/client.rs
+++ b/crates/gem_evm/src/rpc/alchemy/client.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 #[cfg(feature = "reqwest")]
-use gem_client::Client;
+use gem_client::{Client, ContentType, CONTENT_TYPE};
 use primitives::EVMChain;
 use serde_json::json;
 
@@ -33,7 +33,7 @@ impl<C: Client> AlchemyClient<C> {
 
     fn common_headers() -> std::collections::HashMap<String, String> {
         let mut headers = std::collections::HashMap::new();
-        headers.insert("Content-Type".to_string(), "application/json".to_string());
+        headers.insert(CONTENT_TYPE.to_string(), ContentType::ApplicationJson.as_str().to_string());
         headers
     }
 

--- a/crates/gem_evm/src/rpc/alchemy/client.rs
+++ b/crates/gem_evm/src/rpc/alchemy/client.rs
@@ -12,26 +12,26 @@ use crate::{
 };
 use primitives::EVMChain;
 #[cfg(feature = "reqwest")]
-use reqwest_middleware::ClientWithMiddleware;
+use gem_client::Client;
 use serde_json::json;
 
 use crate::rpc::alchemy::TokenBalances;
 
 #[cfg(feature = "reqwest")]
 #[derive(Clone)]
-pub struct AlchemyClient {
+pub struct AlchemyClient<C: Client> {
     pub chain: EVMChain,
     url: String,
-    client: ClientWithMiddleware,
+    client: C,
     ethereum_client: EthereumClient,
 }
 
 #[cfg(feature = "reqwest")]
-impl AlchemyClient {
+impl<C: Client> AlchemyClient<C> {
     const DISABLED_RPC_CHAINS: [EVMChain; 5] = [EVMChain::Mantle, EVMChain::Hyperliquid, EVMChain::OpBNB, EVMChain::Monad, EVMChain::Fantom];
     const ENABLED_TRANSACTION_CHAINS: [EVMChain; 2] = [EVMChain::Ethereum, EVMChain::Base];
 
-    pub fn new(ethereum_client: EthereumClient, client: ClientWithMiddleware, api_key: String) -> Self {
+    pub fn new(ethereum_client: EthereumClient, client: C, api_key: String) -> Self {
         let chain = ethereum_client.chain;
         let url = format!("https://api.g.alchemy.com/data/v1/{api_key}");
 
@@ -86,15 +86,9 @@ impl AlchemyClient {
             ],
             "includeNativeTokens": false,
         });
-        Ok(self
-            .client
-            .post(url)
-            .header("Content-Type", "application/json")
-            .body(serde_json::to_string(&payload)?)
-            .send()
-            .await?
-            .json()
-            .await?)
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("Content-Type".to_string(), "application/json".to_string());
+        Ok(self.client.post(&url, &payload, Some(headers)).await?)
     }
     // https://www.alchemy.com/docs/data/portfolio-apis/portfolio-api-endpoints/portfolio-api-endpoints/get-transaction-history-by-address
     //TODO:
@@ -115,14 +109,8 @@ impl AlchemyClient {
             ],
             "limit": 25,
         });
-        Ok(self
-            .client
-            .post(url)
-            .header("Content-Type", "application/json")
-            .body(serde_json::to_string(&payload)?)
-            .send()
-            .await?
-            .json()
-            .await?)
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("Content-Type".to_string(), "application/json".to_string());
+        Ok(self.client.post(&url, &payload, Some(headers)).await?)
     }
 }

--- a/crates/settings_chain/Cargo.toml
+++ b/crates/settings_chain/Cargo.toml
@@ -5,7 +5,6 @@ edition = { workspace = true }
 
 [dependencies]
 reqwest = { workspace = true }
-reqwest-middleware = { workspace = true }
 url = { workspace = true }
 
 primitives = { path = "../primitives" }

--- a/crates/settings_chain/src/lib.rs
+++ b/crates/settings_chain/src/lib.rs
@@ -4,7 +4,6 @@ pub use chain_providers::ChainProviders;
 use gem_client::{retry::standard_retry_policy, ReqwestClient};
 pub use provider_config::ProviderConfig;
 
-use reqwest_middleware::ClientBuilder;
 
 use gem_chain_rpc::{ethereum::EthereumProvider, tron::TronProvider, ChainProvider, GenericProvider, HyperCoreProvider};
 
@@ -61,7 +60,6 @@ impl ProviderFactory {
 
         let reqwest_client = reqwest::Client::builder().retry(retry_policy).build().expect("Failed to build reqwest client");
 
-        let client = ClientBuilder::new(reqwest_client.clone()).build();
         let chain = config.chain;
         let url = config.url;
         let gem_client = ReqwestClient::new(url.clone(), reqwest_client.clone());
@@ -97,7 +95,7 @@ impl ProviderFactory {
             | Chain::Monad => {
                 let chain = EVMChain::from_chain(chain).unwrap();
                 let ethereum_client = EthereumClient::new(chain, &url);
-                let assets_provider = AlchemyClient::new(ethereum_client.clone(), client.clone(), config.alchemy_key.clone());
+                let assets_provider = AlchemyClient::new(ethereum_client.clone(), gem_client.clone(), config.alchemy_key.clone());
                 let transactions_provider = AnkrClient::new(ethereum_client.clone(), config.ankr_key.clone());
                 Box::new(EthereumProvider::new(
                     ethereum_client,


### PR DESCRIPTION
Replaces usage of reqwest-middleware with gem_client throughout the codebase. Updates CoinGeckoClient and AlchemyClient to use generic client interfaces, simplifies client construction, and updates dependencies accordingly. This change reduces dependency complexity and unifies HTTP client usage.