### PR TITLE
Enhance retry mechanisms with exponential backoff for rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,6 +2995,7 @@ dependencies = [
  "serde_urlencoded",
  "thiserror 2.0.16",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,6 +2994,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "thiserror 2.0.16",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ anyhow = { version = "1.0" }
 clap = { version = "4.5.45", features = ["derive"] }
 lazy_static = "1.5.0"
 futures-util = "0.3.31"
+tracing = { version = "0.1" }
 uuid = { version = "1.18.0", features = ["v4"] }
 rand = { version = "0.9.2" }
 aws-sdk-s3 = { version = "1.103.0", features = ["behavior-version-latest"] }

--- a/crates/coingecko/src/client.rs
+++ b/crates/coingecko/src/client.rs
@@ -56,7 +56,7 @@ impl<C: Client> CoinGeckoClient<C> {
                 }
             },
             3,
-            None, // Use default retry behavior (429, 502, 503, 504, throttling)
+            None::<fn(&Box<dyn Error + Send + Sync>) -> bool>, // Use default retry behavior
         )
         .await
     }

--- a/crates/coingecko/src/client.rs
+++ b/crates/coingecko/src/client.rs
@@ -2,7 +2,7 @@ use crate::model::{
     Coin, CoinGeckoResponse, CoinIds, CoinInfo, CoinMarket, CoinQuery, CointListQuery, Data, ExchangeRates, Global, MarketChart, SearchTrending,
     TopGainersLosers,
 };
-use gem_client::{build_path_with_query, retry::retry_policy, Client, ReqwestClient};
+use gem_client::{build_path_with_query, retry, Client, ReqwestClient};
 use primitives::{FiatRate, DEFAULT_FIAT_CURRENCY};
 use reqwest::header::{HeaderMap, HeaderValue};
 use std::error::Error;
@@ -25,13 +25,7 @@ impl CoinGeckoClient<ReqwestClient> {
         if !api_key.is_empty() {
             headers.insert(COINGECKO_API_HEADER_KEY, HeaderValue::from_str(api_key).unwrap());
         }
-        let mut client_builder = reqwest::Client::builder().default_headers(headers);
-
-        // Only add retry policy for free tier (no API key)
-        if api_key.is_empty() {
-            let retry_policy_config = retry_policy(COINGECKO_API_HOST, 10);
-            client_builder = client_builder.retry(retry_policy_config);
-        }
+        let client_builder = reqwest::Client::builder().default_headers(headers);
 
         let reqwest_client = client_builder.build().unwrap();
         let client = ReqwestClient::new(url, reqwest_client);
@@ -53,11 +47,18 @@ impl<C: Client> CoinGeckoClient<C> {
     where
         T: serde::de::DeserializeOwned,
     {
-        let response: CoinGeckoResponse<T> = self.client.get(path).await?;
-        match response {
-            CoinGeckoResponse::Success(data) => Ok(data),
-            CoinGeckoResponse::Error(error) => Err(error.error.into()),
-        }
+        retry(
+            || async {
+                let response: CoinGeckoResponse<T> = self.client.get(path).await.map_err(|e| -> Box<dyn Error + Send + Sync> { Box::new(e) })?;
+                match response {
+                    CoinGeckoResponse::Success(data) => Ok(data),
+                    CoinGeckoResponse::Error(error) => Err(error.error.into()),
+                }
+            },
+            3,
+            None, // Use default retry behavior (429, 502, 503, 504, throttling)
+        )
+        .await
     }
 
     pub async fn get_global(&self) -> Result<Global, Box<dyn Error + Send + Sync>> {

--- a/crates/gem_client/Cargo.toml
+++ b/crates/gem_client/Cargo.toml
@@ -16,3 +16,4 @@ serde_urlencoded = { workspace = true }
 reqwest = { workspace = true, optional = true }
 hex = { workspace = true }
 tokio = { workspace = true, features = ["time"], optional = true }
+tracing = { workspace = true }

--- a/crates/gem_client/Cargo.toml
+++ b/crates/gem_client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 default = []
-reqwest = ["dep:reqwest"]
+reqwest = ["dep:reqwest", "dep:tokio"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -15,3 +15,4 @@ serde_json = { workspace = true }
 serde_urlencoded = { workspace = true }
 reqwest = { workspace = true, optional = true }
 hex = { workspace = true }
+tokio = { workspace = true, features = ["time"], optional = true }

--- a/crates/gem_client/src/lib.rs
+++ b/crates/gem_client/src/lib.rs
@@ -17,7 +17,7 @@ pub use types::ClientError;
 pub use reqwest_client::ReqwestClient;
 
 #[cfg(feature = "reqwest")]
-pub use retry::{aggressive_retry_policy, retry_policy, standard_retry_policy};
+pub use retry::{retry, retry_policy};
 
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};

--- a/crates/gem_client/src/lib.rs
+++ b/crates/gem_client/src/lib.rs
@@ -17,7 +17,7 @@ pub use types::ClientError;
 pub use reqwest_client::ReqwestClient;
 
 #[cfg(feature = "reqwest")]
-pub use retry::{retry, retry_policy};
+pub use retry::{retry, retry_policy, default_should_retry};
 
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};

--- a/crates/gem_client/src/retry.rs
+++ b/crates/gem_client/src/retry.rs
@@ -85,7 +85,7 @@ where
                 if should_retry_error && attempt < max_retries {
                     attempt += 1;
                     // Exponential backoff: 2^attempt seconds (2s, 4s, 8s, ...) with max cap
-                    let delay = Duration::from_secs(2_u64.saturating_pow(attempt).min(300)); // Cap at 5 minutes
+                    let delay = Duration::from_secs(2_u64.saturating_pow(attempt).min(1800)); // Cap at 30 minutes
                     tracing::warn!(
                         error = %err,
                         attempt = attempt,

--- a/crates/gem_client/src/retry.rs
+++ b/crates/gem_client/src/retry.rs
@@ -1,6 +1,15 @@
 use reqwest::{retry, StatusCode};
+use std::future::Future;
+use std::time::Duration;
+
+#[cfg(feature = "reqwest")]
+use tokio::time::sleep;
 
 /// Create a retry policy for API requests that handles common HTTP error scenarios
+///
+/// NOTE: This uses reqwest's built-in retry mechanism which does NOT implement exponential backoff.
+/// It will retry immediately without delays, which may not be suitable for rate limiting scenarios.
+/// For rate limiting with proper backoff, use the `retry()` function instead.
 pub fn retry_policy<S>(host: S, max_retries: u32) -> retry::Builder
 where
     S: for<'a> PartialEq<&'a str> + Send + Sync + 'static,
@@ -18,18 +27,98 @@ where
     })
 }
 
-/// Standard retry policy for API requests (3 retries)
-pub fn standard_retry_policy<S>(host: S) -> retry::Builder
+/// Retry policy with exponential backoff for rate limiting and transient errors
+///
+/// This function provides proper exponential backoff (2^attempt seconds) for handling
+/// HTTP errors and other transient failures. Uses async sleep when reqwest
+/// feature is enabled, otherwise falls back to blocking sleep.
+///
+/// # Arguments
+/// * `operation` - A closure that returns a Future to be retried
+/// * `max_retries` - Maximum number of retry attempts
+/// * `status_codes` - Optional list of HTTP status codes to retry on (e.g., [429, 502, 503, 504])
+///   If None, defaults to clearly transient errors (429, 502, 503, 504, throttling)
+///
+/// # Example
+/// ```rust
+/// use gem_client::retry::retry;
+///
+/// // Retry on clearly transient errors (429, 502, 503, 504, throttling) - default behavior
+/// let result = retry(
+///     || async { api_client.get("/endpoint").await },
+///     3,
+///     None
+/// ).await;
+///
+/// // Retry only on rate limiting (429)
+/// let result = retry(
+///     || async { api_client.get("/endpoint").await },
+///     3,
+///     Some(vec![429])
+/// ).await;
+///
+/// // Retry on multiple specific status codes (including 500 if desired)
+/// let result = retry(
+///     || async { api_client.get("/endpoint").await },
+///     3,
+///     Some(vec![429, 500, 502, 503, 504])
+/// ).await;
+/// ```
+pub async fn retry<T, E, F, Fut>(operation: F, max_retries: u32, status_codes: Option<Vec<u16>>) -> Result<T, E>
 where
-    S: for<'a> PartialEq<&'a str> + Send + Sync + 'static,
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
 {
-    retry_policy(host, 3)
+    let mut attempt = 0;
+
+    loop {
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(err) => {
+                if should_retry(&err, &status_codes) && attempt < max_retries {
+                    attempt += 1;
+                    // Exponential backoff: 2^attempt seconds (2s, 4s, 8s, ...)
+                    let delay = Duration::from_secs(2_u64.pow(attempt));
+                    println!(
+                        "Retrying after error: {} (attempt {}/{}, waiting {}s)",
+                        err,
+                        attempt,
+                        max_retries,
+                        delay.as_secs()
+                    );
+
+                    #[cfg(feature = "reqwest")]
+                    sleep(delay).await;
+
+                    #[cfg(not(feature = "reqwest"))]
+                    std::thread::sleep(delay);
+
+                    continue;
+                }
+
+                return Err(err);
+            }
+        }
+    }
 }
 
-/// Aggressive retry policy for external APIs (10 retries)
-pub fn aggressive_retry_policy<S>(host: S) -> retry::Builder
-where
-    S: for<'a> PartialEq<&'a str> + Send + Sync + 'static,
-{
-    retry_policy(host, 10)
+/// Check if an error should trigger a retry based on status codes
+fn should_retry<E: std::fmt::Display>(error: &E, status_codes: &Option<Vec<u16>>) -> bool {
+    let error_str = error.to_string().to_lowercase();
+
+    match status_codes {
+        Some(codes) => {
+            // Check for specific status codes only
+            codes.iter().any(|code| error_str.contains(&code.to_string()))
+        }
+        None => {
+            error_str.contains("429") ||                    // Too Many Requests
+            error_str.contains("502") ||                    // Bad Gateway
+            error_str.contains("503") ||                    // Service Unavailable
+            error_str.contains("504") ||                    // Gateway Timeout
+            error_str.contains("too many requests") ||      // Rate limiting messages
+            error_str.contains("throttled") // Throttling messages
+        }
+    }
 }

--- a/crates/settings_chain/src/lib.rs
+++ b/crates/settings_chain/src/lib.rs
@@ -1,7 +1,7 @@
 mod chain_providers;
 mod provider_config;
 pub use chain_providers::ChainProviders;
-use gem_client::{retry::standard_retry_policy, ReqwestClient};
+use gem_client::{retry_policy, ReqwestClient};
 pub use provider_config::ProviderConfig;
 
 use gem_chain_rpc::{ethereum::EthereumProvider, tron::TronProvider, ChainProvider, GenericProvider, HyperCoreProvider};
@@ -55,9 +55,11 @@ impl ProviderFactory {
             .and_then(|u| u.host_str().map(String::from))
             .unwrap_or_default();
 
-        let retry_policy = standard_retry_policy(host);
-
-        let reqwest_client = reqwest::Client::builder().retry(retry_policy).build().expect("Failed to build reqwest client");
+        let retry_policy_config = retry_policy(host, 3);
+        let reqwest_client = reqwest::Client::builder()
+            .retry(retry_policy_config)
+            .build()
+            .expect("Failed to build reqwest client");
 
         let chain = config.chain;
         let url = config.url;


### PR DESCRIPTION
## Summary

This PR enhances the retry mechanisms in `gem_client` to provide proper exponential backoff for API rate limiting scenarios, while maintaining fast immediate retries for transient network issues.

### Key Changes

#### New Exponential Backoff Retry Function
- **Added `retry()` function**: Implements proper exponential backoff (2s, 4s, 8s delays) for rate limiting scenarios
- **Configurable status codes**: Accept optional `Vec<u16>` to specify which HTTP status codes should trigger retries
- **Smart defaults**: When no status codes specified, defaults to clearly transient errors (429, 502, 503, 504, throttling messages)
- **Async-compatible**: Uses `tokio::time::sleep` when reqwest feature enabled, falls back to `std::thread::sleep`

#### Preserved Original Retry Policy
- **Kept `retry_policy()` function**: Uses reqwest's built-in retry mechanism for immediate retries
- **Clear documentation**: Added note that it does NOT implement exponential backoff
- **Appropriate use cases**: Best for transient network failures in blockchain RPC calls

#### Enhanced CoinGecko Client
- **Updated to use exponential backoff**: CoinGecko API calls now use `retry()` with smart defaults
- **Better rate limit handling**: Should significantly reduce 429 failures in GitHub CI
- **Handles multiple error formats**: Works with both JSON error responses and plain "Throttled" messages

#### Restored settings_chain Functionality  
- **Re-enabled retry logic**: Uses `retry_policy()` for immediate retries on RPC calls
- **Appropriate for blockchain RPCs**: Fast recovery from transient network issues without rate limiting concerns

### API Examples

```rust
// For rate limiting scenarios (CoinGecko, external APIs)
retry(operation, 3, None).await  // Smart defaults

// For specific status codes
retry(operation, 3, Some(vec![429])).await  // Just rate limiting
retry(operation, 3, Some(vec![429, 500, 502, 503])).await  // Custom set

// For immediate retries (blockchain RPCs)
let policy = retry_policy(host, 3);
reqwest::Client::builder().retry(policy).build()
```

### Testing

- ✅ All workspace builds pass
- ✅ CoinGecko client tested with rate limiting scenarios  
- ✅ settings_chain RPC retry functionality restored
- ✅ img-downloader tested with both fast and slow request rates

### Impact

This should significantly improve the reliability of:
- **img-downloader in GitHub CI**: Better handling of CoinGecko rate limits with proper backoff
- **Blockchain RPC calls**: Fast recovery from transient network issues
- **External API integrations**: Flexible retry configuration for different scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)