### PR TITLE
Add Equatable to Swift types in typeshare attributes

### DIFF
--- a/crates/primitives/src/asset_price.rs
+++ b/crates/primitives/src/asset_price.rs
@@ -15,7 +15,7 @@ pub struct AssetPrice {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[typeshare(swift = "Sendable")]
+#[typeshare(swift = "Sendable, Equatable")]
 #[serde(rename_all = "camelCase")]
 pub struct AssetMarket {
     pub market_cap: Option<f64>,

--- a/crates/primitives/src/price.rs
+++ b/crates/primitives/src/price.rs
@@ -46,7 +46,7 @@ pub struct PriceFull {
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare(swift = "Sendable")]
+#[typeshare(swift = "Sendable, Equatable")]
 struct PriceData {
     asset: Asset,
     price: Option<Price>,


### PR DESCRIPTION
Updated the typeshare attributes for AssetMarket and PriceData structs to include 'Equatable' in addition to 'Sendable' for Swift. This enables value comparison for these types in Swift code generation.