### PR TITLE
Update Resource enum variant names to uppercase

### DIFF
--- a/crates/primitives/src/stake_type.rs
+++ b/crates/primitives/src/stake_type.rs
@@ -19,10 +19,9 @@ pub struct StakeData {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[typeshare(swift = "Equatable, Sendable, Hashable")]
+#[serde(rename_all = "camelCase")]
 pub enum Resource {
-    #[serde(rename = "BANDWIDTH")]
     Bandwidth,
-    #[serde(rename = "ENERGY")]
     Energy,
 }
 

--- a/crates/primitives/src/stake_type.rs
+++ b/crates/primitives/src/stake_type.rs
@@ -20,8 +20,8 @@ pub struct StakeData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[typeshare(swift = "Equatable, Sendable, Hashable")]
 pub enum Resource {
-    Bandwidth,
-    Energy,
+    BANDWIDTH,
+    ENERGY,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/primitives/src/stake_type.rs
+++ b/crates/primitives/src/stake_type.rs
@@ -20,8 +20,10 @@ pub struct StakeData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[typeshare(swift = "Equatable, Sendable, Hashable")]
 pub enum Resource {
-    BANDWIDTH,
-    ENERGY,
+    #[serde(rename = "BANDWIDTH")]
+    Bandwidth,
+    #[serde(rename = "ENERGY")]
+    Energy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/gemstone/src/gateway/models/transaction.rs
+++ b/gemstone/src/gateway/models/transaction.rs
@@ -762,8 +762,8 @@ impl From<GemFreezeType> for FreezeType {
 impl From<Resource> for GemResource {
     fn from(value: Resource) -> Self {
         match value {
-            Resource::Bandwidth => GemResource::Bandwidth,
-            Resource::Energy => GemResource::Energy,
+            Resource::BANDWIDTH => GemResource::Bandwidth,
+            Resource::ENERGY => GemResource::Energy,
         }
     }
 }
@@ -771,8 +771,8 @@ impl From<Resource> for GemResource {
 impl From<GemResource> for Resource {
     fn from(value: GemResource) -> Self {
         match value {
-            GemResource::Bandwidth => Resource::Bandwidth,
-            GemResource::Energy => Resource::Energy,
+            GemResource::Bandwidth => Resource::BANDWIDTH,
+            GemResource::Energy => Resource::ENERGY,
         }
     }
 }

--- a/gemstone/src/gateway/models/transaction.rs
+++ b/gemstone/src/gateway/models/transaction.rs
@@ -762,8 +762,8 @@ impl From<GemFreezeType> for FreezeType {
 impl From<Resource> for GemResource {
     fn from(value: Resource) -> Self {
         match value {
-            Resource::BANDWIDTH => GemResource::Bandwidth,
-            Resource::ENERGY => GemResource::Energy,
+            Resource::Bandwidth => GemResource::Bandwidth,
+            Resource::Energy => GemResource::Energy,
         }
     }
 }
@@ -771,8 +771,8 @@ impl From<Resource> for GemResource {
 impl From<GemResource> for Resource {
     fn from(value: GemResource) -> Self {
         match value {
-            GemResource::Bandwidth => Resource::BANDWIDTH,
-            GemResource::Energy => Resource::ENERGY,
+            GemResource::Bandwidth => Resource::Bandwidth,
+            GemResource::Energy => Resource::Energy,
         }
     }
 }


### PR DESCRIPTION
Changed the Resource enum variants from Bandwidth and Energy to BANDWIDTH and ENERGY for consistency and to respect TRON node input