### PR TITLE
Add Everstake staking APY fetch and update tests

### DIFF
--- a/crates/gem_evm/Cargo.toml
+++ b/crates/gem_evm/Cargo.toml
@@ -9,8 +9,9 @@ rpc = [
     "gem_jsonrpc/client",
     "dep:async-trait",
     "dep:chain_traits",
+    "dep:reqwest",
 ]
-reqwest = ["gem_jsonrpc/reqwest", "gem_client/reqwest"]
+reqwest = ["gem_jsonrpc/reqwest", "gem_client/reqwest", "dep:reqwest"]
 chain_integration_tests = ["rpc", "reqwest", "settings/testkit"]
 
 [dependencies]
@@ -31,6 +32,7 @@ serde_json = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
 bigdecimal = { workspace = true }
+reqwest = { workspace = true, features = ["json"], optional = true }
 
 # rpc feature
 chrono = { workspace = true }
@@ -41,7 +43,6 @@ chain_traits = { path = "../chain_traits", optional = true }
 primitives = { path = "../primitives", features = ["testkit"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 num-bigint = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
 settings = { path = "../settings", features = ["testkit"] }
 
 [[test]]

--- a/crates/gem_evm/Cargo.toml
+++ b/crates/gem_evm/Cargo.toml
@@ -5,12 +5,7 @@ edition = { workspace = true }
 
 [features]
 default = []
-rpc = [
-    "gem_jsonrpc/client",
-    "dep:async-trait",
-    "dep:chain_traits",
-    "dep:reqwest",
-]
+rpc = ["gem_jsonrpc/client", "dep:async-trait", "dep:chain_traits"]
 reqwest = ["gem_jsonrpc/reqwest", "gem_client/reqwest", "dep:reqwest"]
 chain_integration_tests = ["rpc", "reqwest", "settings/testkit"]
 

--- a/crates/gem_evm/src/everstake/mod.rs
+++ b/crates/gem_evm/src/everstake/mod.rs
@@ -3,9 +3,13 @@ pub mod contracts;
 pub mod mapper;
 #[cfg(feature = "rpc")]
 pub mod state;
+#[cfg(feature = "rpc")]
+pub mod stats;
 
 pub use constants::*;
 pub use contracts::*;
 pub use mapper::*;
 #[cfg(feature = "rpc")]
 pub use state::*;
+#[cfg(feature = "rpc")]
+pub use stats::*;

--- a/crates/gem_evm/src/everstake/mod.rs
+++ b/crates/gem_evm/src/everstake/mod.rs
@@ -3,13 +3,9 @@ pub mod contracts;
 pub mod mapper;
 #[cfg(feature = "rpc")]
 pub mod state;
-#[cfg(feature = "rpc")]
+#[cfg(all(feature = "rpc", feature = "reqwest"))]
 pub mod stats;
 
 pub use constants::*;
 pub use contracts::*;
 pub use mapper::*;
-#[cfg(feature = "rpc")]
-pub use state::*;
-#[cfg(feature = "rpc")]
-pub use stats::*;

--- a/crates/gem_evm/src/everstake/state.rs
+++ b/crates/gem_evm/src/everstake/state.rs
@@ -16,7 +16,7 @@ pub struct EverstakeAccountState {
     pub withdraw_request: WithdrawRequest,
 }
 
-pub async fn fetch_everstake_account_state<C: Client + Clone>(
+pub async fn get_everstake_account_state<C: Client + Clone>(
     client: &EthereumClient<C>,
     address: &str,
 ) -> Result<EverstakeAccountState, Box<dyn Error + Sync + Send>> {

--- a/crates/gem_evm/src/everstake/stats.rs
+++ b/crates/gem_evm/src/everstake/stats.rs
@@ -12,8 +12,8 @@ struct EverstakeStatsResponse {
     apr: f64,
 }
 
-#[cfg(feature = "rpc")]
-pub async fn fetch_everstake_staking_apy() -> Result<Option<f64>, Box<dyn Error + Send + Sync>> {
+#[cfg(all(feature = "rpc", feature = "reqwest"))]
+pub async fn get_everstake_staking_apy() -> Result<Option<f64>, Box<dyn Error + Send + Sync>> {
     let client = ReqwestClient::new(EVERSTAKE_STATS_BASE_URL.to_string(), reqwest::Client::new());
     let stats: EverstakeStatsResponse = client.get(EVERSTAKE_STATS_PATH).await?;
 

--- a/crates/gem_evm/src/everstake/stats.rs
+++ b/crates/gem_evm/src/everstake/stats.rs
@@ -1,0 +1,21 @@
+use gem_client::{Client, ReqwestClient};
+use serde::Deserialize;
+use serde_serializers::deserialize_f64_from_str;
+use std::error::Error;
+
+const EVERSTAKE_STATS_BASE_URL: &str = "https://eth-api-b2c.everstake.one";
+const EVERSTAKE_STATS_PATH: &str = "/api/v1/stats";
+
+#[derive(Deserialize)]
+struct EverstakeStatsResponse {
+    #[serde(deserialize_with = "deserialize_f64_from_str")]
+    apr: f64,
+}
+
+#[cfg(feature = "rpc")]
+pub async fn fetch_everstake_staking_apy() -> Result<Option<f64>, Box<dyn Error + Send + Sync>> {
+    let client = ReqwestClient::new(EVERSTAKE_STATS_BASE_URL.to_string(), reqwest::Client::new());
+    let stats: EverstakeStatsResponse = client.get(EVERSTAKE_STATS_PATH).await?;
+
+    Ok(Some(stats.apr * 100.0))
+}

--- a/crates/gem_evm/src/provider/staking.rs
+++ b/crates/gem_evm/src/provider/staking.rs
@@ -87,7 +87,8 @@ mod chain_integration_tests {
         let client = create_smartchain_test_client();
         let apy = client.get_staking_apy().await?.unwrap();
 
-        println!("SmartChain staking APY: {}%", apy);
+        println!("SmartChain APY: {}", apy);
+        assert!(apy > 0.1, "Max APY should be greater than 0.1%, got: {}", apy);
 
         Ok(())
     }
@@ -97,10 +98,8 @@ mod chain_integration_tests {
         let client = create_ethereum_test_client();
         let apy = client.get_staking_apy().await?.unwrap();
 
-        // Everstake APY should be around 3-6%
-        assert!(apy > 2.0 && apy < 10.0, "APY should be between 2% and 10%, got: {}", apy);
-        println!("Ethereum Everstake APY: {}%", apy);
-
+        assert!(apy > 2.0 && apy < 6.0, "APY should be between 2% and 6%, got: {}", apy);
+        println!("Ethereum APY: {}", apy);
         Ok(())
     }
 

--- a/crates/gem_evm/src/provider/staking.rs
+++ b/crates/gem_evm/src/provider/staking.rs
@@ -83,17 +83,23 @@ mod chain_integration_tests {
     }
 
     #[tokio::test]
+    async fn test_smartchain_get_staking_apy() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let client = create_smartchain_test_client();
+        let apy = client.get_staking_apy().await?.unwrap();
+
+        println!("SmartChain staking APY: {}%", apy);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_ethereum_get_staking_apy() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let client = create_ethereum_test_client();
-        let apy = client.get_staking_apy().await?;
-
-        assert!(apy.is_some());
-        let apy_value = apy.unwrap();
+        let apy = client.get_staking_apy().await?.unwrap();
 
         // Everstake APY should be around 3-6%
-        assert!(apy_value > 2.0 && apy_value < 10.0, "APY should be between 2% and 10%, got: {}", apy_value);
-
-        println!("Ethereum Everstake APY: {}%", apy_value);
+        assert!(apy > 2.0 && apy < 10.0, "APY should be between 2% and 10%, got: {}", apy);
+        println!("Ethereum Everstake APY: {}%", apy);
 
         Ok(())
     }

--- a/crates/gem_evm/src/provider/staking_ethereum.rs
+++ b/crates/gem_evm/src/provider/staking_ethereum.rs
@@ -15,12 +15,12 @@ impl<C: Client + Clone> EthereumClient<C> {
     pub async fn get_ethereum_staking_apy(&self) -> Result<Option<f64>, Box<dyn Error + Sync + Send>> {
         #[cfg(feature = "reqwest")]
         {
-            return get_everstake_staking_apy().await;
+            get_everstake_staking_apy().await
         }
 
         #[cfg(not(feature = "reqwest"))]
         {
-            return Ok(None);
+            Ok(None)
         }
     }
 

--- a/crates/gem_evm/src/provider/staking_ethereum.rs
+++ b/crates/gem_evm/src/provider/staking_ethereum.rs
@@ -4,13 +4,15 @@ use num_traits::Zero;
 use primitives::{AssetBalance, AssetId, Balance, Chain, DelegationBase, DelegationState, DelegationValidator};
 use std::error::Error;
 
-use crate::everstake::{EVERSTAKE_POOL_ADDRESS, fetch_everstake_account_state, map_balance_to_delegation, map_withdraw_request_to_delegations};
+use crate::everstake::{
+    EVERSTAKE_POOL_ADDRESS, fetch_everstake_account_state, fetch_everstake_staking_apy, map_balance_to_delegation, map_withdraw_request_to_delegations,
+};
 use crate::rpc::client::EthereumClient;
 
 #[cfg(feature = "rpc")]
 impl<C: Client + Clone> EthereumClient<C> {
     pub async fn get_ethereum_staking_apy(&self) -> Result<Option<f64>, Box<dyn Error + Sync + Send>> {
-        Ok(Some(3.2))
+        fetch_everstake_staking_apy().await
     }
 
     pub async fn get_ethereum_validators(&self, apy: f64) -> Result<Vec<DelegationValidator>, Box<dyn Error + Sync + Send>> {

--- a/crates/gem_stellar/src/models/account.rs
+++ b/crates/gem_stellar/src/models/account.rs
@@ -26,7 +26,6 @@ pub struct Account {
 }
 
 #[cfg(feature = "rpc")]
-#[cfg(feature = "rpc")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Balance {
     pub balance: String,

--- a/crates/gem_sui/src/provider/preload_mapper.rs
+++ b/crates/gem_sui/src/provider/preload_mapper.rs
@@ -159,9 +159,7 @@ pub fn map_transaction_data(
             let digest = hex::encode(&tx_output.hash);
             Ok(format!("{}_{}", data, digest))
         }
-        TransactionInputType::TransferNft(_, _)
-        | TransactionInputType::Account(_, _)
-        | _ => Err("Unsupported transaction type for Sui".into()),
+        _ => Err("Unsupported transaction type for Sui".into()),
     }
 }
 

--- a/gemstone/src/gateway/mod.rs
+++ b/gemstone/src/gateway/mod.rs
@@ -218,7 +218,7 @@ impl GemGateway {
         let hash = self
             .provider(chain)
             .await?
-            .transaction_broadcast(data, options.into())
+            .transaction_broadcast(data, options)
             .await
             .map_err(|e| GatewayError::NetworkError(e.to_string()))?;
         Ok(hash)

--- a/gemstone/src/models/transaction.rs
+++ b/gemstone/src/models/transaction.rs
@@ -477,7 +477,7 @@ impl From<SwapQuoteData> for GemSwapQuoteData {
             to: value.to,
             value: value.value,
             data: value.data,
-            approval: value.approval.map(|approval| approval.into()),
+            approval: value.approval,
             gas_limit: value.gas_limit,
         }
     }
@@ -694,7 +694,7 @@ impl From<TransactionInputType> for GemTransactionInputType {
             },
             TransactionInputType::TokenApprove(asset, approval_data) => GemTransactionInputType::TokenApprove {
                 asset: asset.into(),
-                approval_data: approval_data.into(),
+                approval_data,
             },
             TransactionInputType::Generic(asset, metadata, extra) => GemTransactionInputType::Generic {
                 asset: asset.into(),
@@ -703,7 +703,7 @@ impl From<TransactionInputType> for GemTransactionInputType {
             },
             TransactionInputType::TransferNft(asset, nft_asset) => GemTransactionInputType::TransferNft {
                 asset: asset.into(),
-                nft_asset: nft_asset.into(),
+                nft_asset,
             },
             TransactionInputType::Account(asset, account_type) => GemTransactionInputType::Account {
                 asset: asset.into(),
@@ -933,7 +933,7 @@ impl From<GemTransactionInputType> for TransactionInputType {
                 },
             ),
             GemTransactionInputType::Generic { asset, metadata, extra } => TransactionInputType::Generic(asset.into(), metadata.into(), extra.into()),
-            GemTransactionInputType::TransferNft { asset, nft_asset } => TransactionInputType::TransferNft(asset.into(), nft_asset.into()),
+            GemTransactionInputType::TransferNft { asset, nft_asset } => TransactionInputType::TransferNft(asset.into(), nft_asset),
             GemTransactionInputType::Account { asset, account_type } => TransactionInputType::Account(asset.into(), account_type.into()),
             GemTransactionInputType::Perpetual { asset, perpetual_type } => TransactionInputType::Perpetual(asset.into(), perpetual_type.into()),
         }

--- a/gemstone/tests/integration_test.rs
+++ b/gemstone/tests/integration_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "reqwest_provider")]
+
 #[cfg(test)]
 mod tests {
     use gem_solana::{jsonrpc::SolanaRpc, models::blockhash::SolanaBlockhashResult};


### PR DESCRIPTION
Introduces fetch_everstake_staking_apy to retrieve APY from Everstake API and integrates it into Ethereum staking logic. Updates integration tests to validate APY fetching for both SmartChain and Ethereum, and refines Cargo.toml to handle reqwest dependencies for the new functionality.