### PR TITLE
Add Onboarding variant to BannerEvent enum

### DIFF
--- a/crates/primitives/src/banner.rs
+++ b/crates/primitives/src/banner.rs
@@ -17,6 +17,7 @@ pub enum BannerEvent {
     AccountBlockedMultiSignature,
     ActivateAsset,
     SuspiciousAsset,
+    Onboarding,
 }
 
 #[typeshare(swift = "Equatable, CaseIterable, Sendable")]


### PR DESCRIPTION
Introduces a new Onboarding variant to the BannerEvent enum in banner.rs to support onboarding-related banner events.