### PR TITLE
feat: add plasma network support

### DIFF
--- a/Settings.yaml
+++ b/Settings.yaml
@@ -149,6 +149,8 @@ chains:
     url: https://blockbook.doge.zelcore.io
   world:
     url: https://worldchain-mainnet.gateway.tenderly.co
+  plasma:
+    url: https://rpc.plasma.to
   stellar:
     url: https://horizon.stellar.org
   sonic:

--- a/crates/chain_primitives/src/token_id.rs
+++ b/crates/chain_primitives/src/token_id.rs
@@ -28,6 +28,7 @@ pub fn format_token_id(chain: Chain, token_id: String) -> Option<String> {
         | Chain::Unichain
         | Chain::Hyperliquid
         | Chain::HyperCore
+        | Chain::Plasma
         | Chain::Monad => Address::from_str(&token_id).ok().map(|address| address.to_checksum(None)),
         Chain::Solana | Chain::Ton | Chain::Near => Some(token_id),
         Chain::Tron => (token_id.len() == 34 && token_id.starts_with('T')).then_some(token_id),

--- a/crates/coingecko/src/mapper.rs
+++ b/crates/coingecko/src/mapper.rs
@@ -65,7 +65,6 @@ pub fn get_coingecko_market_id_for_chain(chain: Chain) -> &'static str {
         | Chain::Linea
         | Chain::Manta
         | Chain::World
-        | Chain::Plasma
         | Chain::Abstract
         | Chain::Ink
         | Chain::Unichain => "ethereum",
@@ -100,5 +99,6 @@ pub fn get_coingecko_market_id_for_chain(chain: Chain) -> &'static str {
         Chain::Hyperliquid => "hyperliquid",
         Chain::HyperCore => "hyperliquid",
         Chain::Monad => "monad",
+        Chain::Plasma => "plasma",
     }
 }

--- a/crates/coingecko/src/mapper.rs
+++ b/crates/coingecko/src/mapper.rs
@@ -65,6 +65,7 @@ pub fn get_coingecko_market_id_for_chain(chain: Chain) -> &'static str {
         | Chain::Linea
         | Chain::Manta
         | Chain::World
+        | Chain::Plasma
         | Chain::Abstract
         | Chain::Ink
         | Chain::Unichain => "ethereum",

--- a/crates/gem_evm/src/multicall3.rs
+++ b/crates/gem_evm/src/multicall3.rs
@@ -88,6 +88,6 @@ pub fn deployment_by_chain(chain: &EVMChain) -> &'static str {
         | EVMChain::Unichain
         | EVMChain::Hyperliquid => "0xcA11bde05977b3631167028862bE2a173976CA11",
         EVMChain::ZkSync | EVMChain::Abstract => "0xF9cda624FBC7e059355ce98a31693d299FACd963",
-        EVMChain::Monad => "", //TODO: Monad
+        EVMChain::Plasma | EVMChain::Monad => "", //TODO: Monad
     }
 }

--- a/crates/gem_evm/src/rpc/ankr/model.rs
+++ b/crates/gem_evm/src/rpc/ankr/model.rs
@@ -56,6 +56,7 @@ pub fn ankr_chain(chain: EVMChain) -> Option<String> {
         EVMChain::Ink => None,
         EVMChain::Unichain => None,
         EVMChain::Hyperliquid => None,
+        EVMChain::Plasma => None,
         EVMChain::Monad => None,
     }
 }

--- a/crates/pricer_dex/src/pyth/mapper.rs
+++ b/crates/pricer_dex/src/pyth/mapper.rs
@@ -41,6 +41,7 @@ pub fn price_account_for_chain(chain: Chain) -> &'static str {
         Chain::Stellar => "DMw1AaDmW9g8cCcB4KqCAdWiDNkyFJg7cQ6nhdHpMN6j",
         Chain::Algorand => "HqFyq1wh1xKvL7KDqqT7NJeSPdAqsDqnmBisUC2XdXAX",
         Chain::Polkadot => "EcV1X1gY2yb4KXxjVQtTHTbioum2gvmPnFk4zYAt7zne",
+        Chain::Plasma => "JBu1AL4obBcCMqKBBxhpWCNUt136ijcuMZLFvTP7iWdB",
         Chain::Cardano => "3pyn4svBbxJ9Wnn3RVeafyLWfzie6yC5eTig2S62v9SC",
         Chain::Berachain => "B72vp52SUipn1gaBadkBk5MSMjMqS8gSaNUz4jBkAm9E",
         Chain::Hyperliquid | Chain::HyperCore => "5UVhvt9NzyyVuVaePfkaEaHD6hoD9Dw7PFUCfRoMh8i6",

--- a/crates/primitives/src/asset.rs
+++ b/crates/primitives/src/asset.rs
@@ -101,6 +101,7 @@ impl Asset {
             Chain::Sonic => chain.new_asset("Sonic".to_string(), "S".to_string(), 18, AssetType::NATIVE),
             Chain::Algorand => chain.new_asset("Algorand".to_string(), "ALGO".to_string(), 6, AssetType::NATIVE),
             Chain::Polkadot => chain.new_asset("Polkadot".to_string(), "DOT".to_string(), 10, AssetType::NATIVE),
+            Chain::Plasma => chain.new_asset("Plasma".to_string(), "XPL".to_string(), 18, AssetType::NATIVE),
             Chain::Cardano => chain.new_asset("Cardano".to_string(), "ADA".to_string(), 6, AssetType::NATIVE),
             Chain::Abstract => chain.new_asset("Abstract".to_string(), "ETH".to_string(), 18, AssetType::NATIVE),
             Chain::Berachain => chain.new_asset("Berachain".to_string(), "BERA".to_string(), 18, AssetType::NATIVE),

--- a/crates/primitives/src/block_explorer.rs
+++ b/crates/primitives/src/block_explorer.rs
@@ -67,6 +67,7 @@ pub fn get_block_explorers(chain: Chain) -> Vec<Box<dyn BlockExplorer>> {
         Chain::Celo => vec![BlockScout::new_celo(), EtherScan::boxed(EVMChain::Celo)],
         Chain::ZkSync => vec![ZkSync::boxed(), EtherScan::boxed(EVMChain::ZkSync)],
         Chain::World => vec![EtherScan::boxed(EVMChain::World)],
+        Chain::Plasma => vec![EtherScan::boxed(EVMChain::Plasma)],
         Chain::Solana => vec![solana::new_solscan(), solana::new_solana_fm(), blockchair::new_solana()],
         Chain::Thorchain => vec![RuneScan::boxed(), Viewblock::boxed()],
 

--- a/crates/primitives/src/chain.rs
+++ b/crates/primitives/src/chain.rs
@@ -350,7 +350,6 @@ impl Chain {
             | Self::Hyperliquid
             | Self::Sui
             | Self::Monad
-            | Self::Plasma
             | Self::Ton
             | Self::Xrp
             | Self::Berachain => true,
@@ -365,7 +364,8 @@ impl Chain {
             | Self::Algorand
             | Self::Polkadot
             | Self::Cardano
-            | Self::HyperCore => false,
+            | Self::HyperCore
+            | Self::Plasma => false,
         }
     }
 

--- a/crates/primitives/src/chain.rs
+++ b/crates/primitives/src/chain.rs
@@ -50,6 +50,7 @@ pub enum Chain {
     Sonic,
     Algorand,
     Polkadot,
+    Plasma,
     Cardano,
     Abstract,
     Berachain,
@@ -126,6 +127,7 @@ impl Chain {
             Self::Sonic => "146",
             Self::Algorand => "mainnet-v1.0",
             Self::Polkadot => "Polkadot",
+            Self::Plasma => "9745",
             Self::Cardano => "764824073", // magic number from genesis configuration
             Self::Abstract => "2741",
             Self::Berachain => "80094",
@@ -170,6 +172,7 @@ impl Chain {
             | Self::Unichain
             | Self::Hyperliquid
             | Self::HyperCore
+            | Self::Plasma
             | Self::Monad => 60,
             Self::Bitcoin => 0,
             Self::BitcoinCash => 145,
@@ -218,6 +221,7 @@ impl Chain {
             | Self::Ink
             | Self::Unichain
             | Self::Hyperliquid
+            | Self::Plasma
             | Self::Monad => ChainType::Ethereum,
             Self::Bitcoin | Self::BitcoinCash | Self::Doge | Self::Litecoin => ChainType::Bitcoin,
             Self::Solana => ChainType::Solana,
@@ -260,6 +264,7 @@ impl Chain {
             | Self::Unichain
             | Self::Hyperliquid
             | Self::HyperCore
+            | Self::Plasma
             | Self::Monad => Some(AssetType::ERC20),
             Self::OpBNB | Self::SmartChain => Some(AssetType::BEP20),
             Self::Solana => Some(AssetType::SPL),
@@ -345,6 +350,7 @@ impl Chain {
             | Self::Hyperliquid
             | Self::Sui
             | Self::Monad
+            | Self::Plasma
             | Self::Ton
             | Self::Xrp
             | Self::Berachain => true,
@@ -398,6 +404,7 @@ impl Chain {
             | Self::Optimism
             | Self::World
             | Self::Berachain
+            | Self::Plasma
             | Self::Thorchain => 2_000,
             Self::Polygon | Self::Tron => 3_000,
             Self::Algorand | Self::Xrp => 4_000,
@@ -451,6 +458,7 @@ impl Chain {
             | Self::World
             | Self::Stellar
             | Self::Sonic
+            | Self::Plasma
             | Self::Algorand
             | Self::Cardano => 30,
             Self::Noble => 20,

--- a/crates/primitives/src/chain_evm.rs
+++ b/crates/primitives/src/chain_evm.rs
@@ -53,7 +53,7 @@ impl EVMChain {
             Self::Ethereum => 100_000_000,                                                        // https://etherscan.io/gastracker
             Self::SmartChain => 100_000_000,                                                      // https://bscscan.com/gastracker
             Self::Polygon => 30_000_000_000,                                                      // https://polygonscan.com/gastracker
-            Self::Plasma => 100_000,                                                              // plasma baseline
+            Self::Plasma => 100_000,                                                              // https://plasmascan.to/insight/leaderboard/gas-tracker
             Self::Arbitrum => 10_000_000, // https://arbiscan.io/address/0x000000000000000000000000000000000000006C#readContract getMinimumGasPrice
             Self::Optimism => 1_000_000,  // https://optimistic.etherscan.io/chart/gasprice
             Self::Base => 5_000_000,      // https://basescan.org/chart/gasprice

--- a/crates/primitives/src/chain_evm.rs
+++ b/crates/primitives/src/chain_evm.rs
@@ -19,6 +19,7 @@ pub enum EVMChain {
     Ethereum,
     SmartChain,
     Polygon,
+    Plasma,
     Arbitrum,
     Optimism,
     Base,
@@ -52,6 +53,7 @@ impl EVMChain {
             Self::Ethereum => 100_000_000,                                                        // https://etherscan.io/gastracker
             Self::SmartChain => 100_000_000,                                                      // https://bscscan.com/gastracker
             Self::Polygon => 30_000_000_000,                                                      // https://polygonscan.com/gastracker
+            Self::Plasma => 100_000,                                                              // plasma baseline
             Self::Arbitrum => 10_000_000, // https://arbiscan.io/address/0x000000000000000000000000000000000000006C#readContract getMinimumGasPrice
             Self::Optimism => 1_000_000,  // https://optimistic.etherscan.io/chart/gasprice
             Self::Base => 5_000_000,      // https://basescan.org/chart/gasprice
@@ -81,6 +83,7 @@ impl EVMChain {
             | Self::AvalancheC
             | Self::Fantom
             | Self::Gnosis
+            | Self::Plasma
             | Self::Manta
             | Self::Blast
             | Self::Linea
@@ -140,7 +143,8 @@ impl EVMChain {
             Self::Linea => Some("0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f"),
             Self::Mantle => Some("0x78c1b0C915c4FAA5FffA6CAbf0219DA63d7f4cb8"), // Wrapped Mantle (WMNT)
             Self::Manta => Some("0x0dc808adce2099a9f62aa87d9670745aba741746"),
-            Self::Monad => None, //TODO: Monad
+            Self::Plasma => Some("0x6100E367285b01F48D07953803A2d8dCA5D19873"), // Wrapped Plasma (WXPL)
+            Self::Monad => None,                                                //TODO: Monad
         }
     }
 

--- a/crates/primitives/src/explorers/etherscan.rs
+++ b/crates/primitives/src/explorers/etherscan.rs
@@ -10,6 +10,7 @@ impl EtherScan {
             EVMChain::Ethereum => Explorer::boxed(Metadata::with_token("Etherscan", "https://etherscan.io")),
             EVMChain::SmartChain => Explorer::boxed(Metadata::with_token("BscScan", "https://bscscan.com")),
             EVMChain::Polygon => Explorer::boxed(Metadata::with_token("PolygonScan", "https://polygonscan.com")),
+            EVMChain::Plasma => Explorer::boxed(Metadata::with_token("PlasmaScan", "https://plasmascan.to")),
             EVMChain::Arbitrum => Explorer::boxed(Metadata::with_token("ArbiScan", "https://arbiscan.io")),
             EVMChain::Optimism => Explorer::boxed(Metadata::with_token("Etherscan", "https://optimistic.etherscan.io")),
             EVMChain::Base => Explorer::boxed(Metadata::with_token("BaseScan", "https://basescan.org")),

--- a/crates/primitives/src/node_config.rs
+++ b/crates/primitives/src/node_config.rs
@@ -137,6 +137,7 @@ pub fn get_nodes_for_chain(chain: Chain) -> Vec<Node> {
         Chain::Sonic => vec![Node::new("https://rpc.soniclabs.com", NodePriority::High)],
         Chain::Algorand => vec![Node::new("https://mainnet-api.algonode.cloud", NodePriority::High)],
         Chain::Polkadot => vec![Node::new("https://polkadot-public-sidecar.parity-chains.parity.io", NodePriority::High)],
+        Chain::Plasma => vec![Node::new("https://rpc.plasma.to", NodePriority::High)],
         Chain::Cardano => vec![],
         Chain::Abstract => vec![Node::new("https://api.mainnet.abs.xyz", NodePriority::High)],
         Chain::Berachain => vec![Node::new("https://rpc.berachain.com", NodePriority::High)],

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -211,6 +211,7 @@ pub struct Chains {
     pub celo: Chain,
     pub near: Chain,
     pub world: Chain,
+    pub plasma: Chain,
     pub stellar: Chain,
     pub sonic: Chain,
     pub algorand: Chain,

--- a/crates/settings_chain/src/lib.rs
+++ b/crates/settings_chain/src/lib.rs
@@ -87,6 +87,7 @@ impl ProviderFactory {
             | Chain::Mantle
             | Chain::Celo
             | Chain::World
+            | Chain::Plasma
             | Chain::Sonic
             | Chain::Abstract
             | Chain::Berachain
@@ -169,6 +170,7 @@ impl ProviderFactory {
             Chain::Celo => settings.chains.celo.get_type(),
             Chain::Near => settings.chains.near.get_type(),
             Chain::World => settings.chains.world.get_type(),
+            Chain::Plasma => settings.chains.plasma.get_type(),
             Chain::Stellar => settings.chains.stellar.get_type(),
             Chain::Sonic => settings.chains.sonic.get_type(),
             Chain::Algorand => settings.chains.algorand.get_type(),

--- a/gemstone/src/gateway/mod.rs
+++ b/gemstone/src/gateway/mod.rs
@@ -134,6 +134,7 @@ impl GemGateway {
             | Chain::Ink
             | Chain::Unichain
             | Chain::Hyperliquid
+            | Chain::Plasma
             | Chain::Monad => Ok(Arc::new(EthereumClient::new(
                 jsonrpc_client_with_chain(self.provider.clone(), chain),
                 EVMChain::from_chain(chain).unwrap(),


### PR DESCRIPTION
## Summary
- add Plasma chain metadata, RPC, and asset wiring across primitives and settings
- register Plasma EVM configuration with min priority fee baselines and wxpl address
- document Plasma explorer/node availability and note missing multicall3 deployment

## Testing
- cargo check -p primitives
- cargo check -p gem_evm
