### PR TITLE
Add Plasma USDT asset support for Across

### DIFF
--- a/crates/gem_evm/src/across/deployment.rs
+++ b/crates/gem_evm/src/across/deployment.rs
@@ -3,7 +3,7 @@ use crate::ether_conv::EtherConv;
 use alloy_primitives::map::HashSet;
 use num_bigint::BigInt;
 use primitives::{AssetId, Chain, asset_constants::*};
-use std::collections::HashMap;
+use std::{collections::HashMap, vec};
 
 pub const ACROSS_CONFIG_STORE: &str = "0x3B03509645713718B78951126E0A6de6f10043f5";
 pub const ACROSS_HUBPOOL: &str = "0xc186fA914353c44b2E33eBE05f21846F1048bEda";
@@ -77,6 +77,10 @@ impl AcrossDeployment {
                 chain_id,
                 spoke_pool: "0x35E63eA3eb0fb7A3bc543C71FB66412e1F6B0E04",
             }),
+            Chain::Plasma => Some(Self {
+                chain_id,
+                spoke_pool: "0x50039fAEfebef707cFD94D6d462fE6D10B39207a",
+            }),
             _ => None,
         }
     }
@@ -89,8 +93,8 @@ impl AcrossDeployment {
             324 => "0x863859ef502F0Ee9676626ED5B418037252eFeb2".into(),
             // SmartChain
             56 => "0xAC537C12fE8f544D712d71ED4376a502EEa944d7".into(),
-            // HyperEvm
-            999 => "0x5E7840E06fAcCb6d1c3b5F5E0d1d3d07F2829bba".into(),
+            // HyperEvm | Plasma
+            999 | 9745 => "0x5E7840E06fAcCb6d1c3b5F5E0d1d3d07F2829bba".into(),
             _ => MULTICALL_HANDLER.into(),
         }
     }
@@ -119,6 +123,7 @@ impl AcrossDeployment {
             (Chain::Ink, vec![WETH_INK_ASSET_ID.into(), USDT_INK_ASSET_ID.into()]),
             (Chain::Unichain, vec![WETH_UNICHAIN_ASSET_ID.into(), USDC_UNICHAIN_ASSET_ID.into()]),
             (Chain::SmartChain, vec![ETH_SMARTCHAIN_ASSET_ID.into()]),
+            (Chain::Plasma, vec![USDT_PLASMA_ASSET_ID.into()]),
         ])
     }
 
@@ -189,6 +194,7 @@ impl AcrossDeployment {
                     USDT_ZKSYNC_ASSET_ID.into(),
                     USDT_INK_ASSET_ID.into(),
                     USDT_HYPEREVM_ASSET_ID.into(),
+                    USDT_PLASMA_ASSET_ID.into(),
                 ]),
             },
             // USDT on BSC decimals are 18

--- a/crates/primitives/src/asset_constants.rs
+++ b/crates/primitives/src/asset_constants.rs
@@ -67,6 +67,7 @@ pub const USDT_SMARTCHAIN_ASSET_ID: &str = "smartchain_0x55d398326f99059fF775485
 pub const USDT_AVAX_ASSET_ID: &str = "avalanchec_0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7";
 pub const USDT_INK_ASSET_ID: &str = "ink_0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96"; // USDT0
 pub const USDT_HYPEREVM_ASSET_ID: &str = "hyperliquid_0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb"; // USDT0
+pub const USDT_PLASMA_ASSET_ID: &str = "plasma_0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb";
 
 // WBTC
 pub const WBTC_ARB_ASSET_ID: &str = "arbitrum_0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f";

--- a/gemstone/src/swapper/across/provider.rs
+++ b/gemstone/src/swapper/across/provider.rs
@@ -278,6 +278,7 @@ impl Swapper for Across {
             SwapperChainAsset::Assets(Chain::Unichain, vec![UNICHAIN_WETH.id.clone(), UNICHAIN_USDC.id.clone()]),
             SwapperChainAsset::Assets(Chain::SmartChain, vec![SMARTCHAIN_ETH.id.clone()]),
             SwapperChainAsset::Assets(Chain::Hyperliquid, vec![HYPEREVM_USDC.id.clone(), HYPEREVM_USDT.id.clone()]),
+            SwapperChainAsset::Assets(Chain::Plasma, vec![PLASMA_USDT.id.clone()]),
         ]
     }
 

--- a/gemstone/src/swapper/asset.rs
+++ b/gemstone/src/swapper/asset.rs
@@ -264,6 +264,9 @@ pub static HYPEREVM_USDC: LazyLock<Asset> =
     LazyLock::new(|| Asset::new(USDC_HYPEREVM_ASSET_ID.into(), USDC_NAME.to_owned(), USDC_SYMBOL.to_owned(), 6, AssetType::ERC20));
 pub static HYPEREVM_USDT: LazyLock<Asset> =
     LazyLock::new(|| Asset::new(USDT_HYPEREVM_ASSET_ID.into(), USDT_NAME.to_owned(), USDT_SYMBOL.to_owned(), 6, AssetType::ERC20));
+// Plasma
+pub static PLASMA_USDT: LazyLock<Asset> =
+    LazyLock::new(|| Asset::new(USDT_PLASMA_ASSET_ID.into(), USDT_NAME.to_owned(), USDT_SYMBOL.to_owned(), 6, AssetType::ERC20));
 // Solana
 pub static SOLANA_USDC: LazyLock<Asset> = LazyLock::new(|| {
     Asset::new(


### PR DESCRIPTION
Introduces USDT asset support for the Plasma chain by defining its asset ID, adding it to asset lists in deployment and swapper modules, and registering the Plasma USDT asset in the asset registry. This enables Plasma chain compatibility for USDT swaps and deployments.