### PR TITLE
Refactor SpotMetadataResponse structure and usage

### DIFF
--- a/crates/gem_hypercore/src/models/token.rs
+++ b/crates/gem_hypercore/src/models/token.rs
@@ -10,6 +10,8 @@ pub struct SpotToken {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SpotMetadataResponse {
+pub struct SpotTokensResponse {
     pub tokens: Vec<SpotToken>,
 }
+
+pub type SpotMetadataResponse = (SpotTokensResponse, serde_json::Value);

--- a/crates/gem_hypercore/src/models/token.rs
+++ b/crates/gem_hypercore/src/models/token.rs
@@ -14,4 +14,12 @@ pub struct SpotTokensResponse {
     pub tokens: Vec<SpotToken>,
 }
 
-pub type SpotMetadataResponse = (SpotTokensResponse, serde_json::Value);
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SpotMetadataResponse(pub (SpotTokensResponse, serde_json::Value));
+
+impl SpotMetadataResponse {
+    pub fn token_data(&self) -> &SpotTokensResponse {
+        &self.0.0
+    }
+}

--- a/crates/gem_hypercore/src/provider/balances_mapper.rs
+++ b/crates/gem_hypercore/src/provider/balances_mapper.rs
@@ -25,7 +25,7 @@ pub fn map_balance_tokens(
         .filter_map(|token_id| {
             let parts = AssetId::decode_token_id(token_id);
             let symbol = parts.first()?;
-            let token = spot_metadata.0.tokens.iter().find(|t| &t.name == symbol)?;
+            let token = spot_metadata.token_data().tokens.iter().find(|t| &t.name == symbol)?;
             let balance = spot_balances.balances.iter().find(|b| b.token == token.index as u32)?;
             map_balance_token(balance.total.clone(), token_id.clone(), token.wei_decimals, chain).ok()
         })
@@ -47,7 +47,7 @@ mod tests {
     use super::*;
     use crate::models::{
         balance::{Balance, Balances, StakeBalance},
-        token::{SpotToken, SpotTokensResponse},
+        token::{SpotMetadataResponse, SpotToken, SpotTokensResponse},
     };
     use primitives::Chain;
 
@@ -79,7 +79,7 @@ mod tests {
             }],
         };
 
-        let spot_metadata = (
+        let spot_metadata = SpotMetadataResponse((
             SpotTokensResponse {
                 tokens: vec![SpotToken {
                     name: "USDC".to_string(),
@@ -89,7 +89,7 @@ mod tests {
                 }],
             },
             serde_json::json!({}),
-        );
+        ));
 
         let token_ids_by_symbol = vec!["USDC".to_string()];
         let results = map_balance_tokens(&spot_balances, &spot_metadata, &token_ids_by_symbol, Chain::HyperCore);

--- a/crates/gem_hypercore/src/provider/balances_mapper.rs
+++ b/crates/gem_hypercore/src/provider/balances_mapper.rs
@@ -25,7 +25,7 @@ pub fn map_balance_tokens(
         .filter_map(|token_id| {
             let parts = AssetId::decode_token_id(token_id);
             let symbol = parts.first()?;
-            let token = spot_metadata.tokens.iter().find(|t| &t.name == symbol)?;
+            let token = spot_metadata.0.tokens.iter().find(|t| &t.name == symbol)?;
             let balance = spot_balances.balances.iter().find(|b| b.token == token.index as u32)?;
             map_balance_token(balance.total.clone(), token_id.clone(), token.wei_decimals, chain).ok()
         })
@@ -47,7 +47,7 @@ mod tests {
     use super::*;
     use crate::models::{
         balance::{Balance, Balances, StakeBalance},
-        token::{SpotMetadataResponse, SpotToken},
+        token::{SpotToken, SpotTokensResponse},
     };
     use primitives::Chain;
 
@@ -79,14 +79,17 @@ mod tests {
             }],
         };
 
-        let spot_metadata = SpotMetadataResponse {
-            tokens: vec![SpotToken {
-                name: "USDC".to_string(),
-                wei_decimals: 8,
-                index: 0,
-                token_id: "0x6d1e7cde53ba9467b783cb7c530ce054".to_string(),
-            }],
-        };
+        let spot_metadata = (
+            SpotTokensResponse {
+                tokens: vec![SpotToken {
+                    name: "USDC".to_string(),
+                    wei_decimals: 8,
+                    index: 0,
+                    token_id: "0x6d1e7cde53ba9467b783cb7c530ce054".to_string(),
+                }],
+            },
+            serde_json::json!({}),
+        );
 
         let token_ids_by_symbol = vec!["USDC".to_string()];
         let results = map_balance_tokens(&spot_balances, &spot_metadata, &token_ids_by_symbol, Chain::HyperCore);

--- a/crates/gem_hypercore/src/provider/token.rs
+++ b/crates/gem_hypercore/src/provider/token.rs
@@ -12,6 +12,7 @@ impl<C: Client> ChainToken for HyperCoreClient<C> {
     async fn get_token_data(&self, token_id: String) -> Result<Asset, Box<dyn Error + Sync + Send>> {
         let spot_metadata = self.get_spot_metadata().await?;
         let token = spot_metadata
+            .0
             .tokens
             .iter()
             .find(|t| t.name == token_id)

--- a/crates/gem_hypercore/src/provider/token.rs
+++ b/crates/gem_hypercore/src/provider/token.rs
@@ -12,7 +12,7 @@ impl<C: Client> ChainToken for HyperCoreClient<C> {
     async fn get_token_data(&self, token_id: String) -> Result<Asset, Box<dyn Error + Sync + Send>> {
         let spot_metadata = self.get_spot_metadata().await?;
         let token = spot_metadata
-            .0
+            .token_data()
             .tokens
             .iter()
             .find(|t| t.name == token_id)

--- a/crates/gem_hypercore/src/rpc/client.rs
+++ b/crates/gem_hypercore/src/rpc/client.rs
@@ -159,7 +159,7 @@ impl<C: Client> HyperCoreClient<C> {
     }
 
     pub async fn get_spot_metadata(&self) -> Result<SpotMetadataResponse, Box<dyn Error + Send + Sync>> {
-        self.info(json!({"type": "spotMeta"})).await
+        self.info(json!({"type": "spotMetaAndAssetCtxs"})).await
     }
 
     pub async fn get_candlesticks(&self, coin: &str, interval: &str, start_time: i64, end_time: i64) -> Result<Vec<Candlestick>, Box<dyn Error + Send + Sync>> {


### PR DESCRIPTION
Updated SpotMetadataResponse to be a tuple of SpotTokensResponse and serde_json::Value, reflecting additional context data. Adjusted all usages and tests to accommodate the new structure, and updated the RPC call to request 'spotMetaAndAssetCtxs' instead of 'spotMeta'.