### PR TITLE
Update Sui and Alloy dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f56873f3cac7a2c63d8e98a4314b8311aa96adb1a0f82ae923eb2119809d2c"
+checksum = "a6c2905bafc2df7ccd32ca3af13f0b0d82f2e2ff9dfbeb12196c0d978d5c0deb"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125a1c373261b252e53e04d6e92c37d881833afc1315fceab53fd46045695640"
+checksum = "a2acb6637a9c0e1cdf8971e0ced8f3fa34c04c5e9dccf6bb184f6a64fe0e37d8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20d867dcf42019d4779519a1ceb55eba8d7f3d0e4f0a89bcba82b8f9eb01e48"
+checksum = "78c84c3637bee9b5c4a4d2b93360ee16553d299c3b932712353caf1cea76d0e6"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74e91b0b553c115d14bd0ed41898309356dc85d0e3d4b9014c4e7715e48c8ad"
+checksum = "a882aa4e1790063362434b9b40d358942b188477ac1c44cfb8a52816ffc0cc17"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84194d31220803f5f62d0a00f583fd3a062b36382e2bea446f1af96727754565"
+checksum = "18e5772107f9bb265d8d8c86e0733937bb20d0857ea5425b1b6ddf51a9804042"
 dependencies = [
  "const-hex",
  "dunce",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8c27b3cf6b2bb8361904732f955bc7c05e00be5f469cec7e2280b6167f3ff0"
+checksum = "e188b939aa4793edfaaa099cb1be4e620036a775b4bdf24fdc56f1cd6fd45890"
 dependencies = [
  "serde",
  "winnow",
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5383d34ea00079e6dd89c652bcbdb764db160cef84e6250926961a0b2295d04"
+checksum = "c3c8a9a909872097caffc05df134e5ef2253a1cdb56d3a9cf0052a042ac763f9"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -6732,16 +6732,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sui-sdk-types"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30a15cf9fdc969f8a2164465eb71debf5753bab1b0790a5d7727ecef7cd912"
+checksum = "b93d1df9a0c26c1e7da6cee2048a8eb9a3ed3233fbd055dbcd131efa4d1e2a74"
 dependencies = [
  "base64ct",
  "bcs",
  "blake2",
  "bnum",
  "bs58",
- "hex",
+ "bytes",
+ "bytestring",
  "itertools 0.13.0",
  "roaring",
  "serde",
@@ -6753,9 +6754,9 @@ dependencies = [
 
 [[package]]
 name = "sui-transaction-builder"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf69d010e68b63878135bbddd6a14d531674ac4ac1d443cdba0ad7ee2d4fad3"
+checksum = "0414735a4ae99588b8525614ea1d6f103f7806a86d41920e4271ac6113d45933"
 dependencies = [
  "base64ct",
  "bcs",
@@ -6790,9 +6791,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b198d366dbec045acfcd97295eb653a7a2b40e4dc764ef1e79aafcad439d3c"
+checksum = "2375c17f6067adc651d8c2c51658019cef32edfff4a982adaf1d7fd1c039f08b"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,13 @@ serde_json = { version = "1.0.145", features = ["preserve_order"] }
 serde_urlencoded = { version = "0.7.1" }
 
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
-reqwest = { version = "0.12.23", features = ["json", "gzip", "brotli", "deflate", "http2"] }
+reqwest = { version = "0.12.23", features = [
+    "json",
+    "gzip",
+    "brotli",
+    "deflate",
+    "http2",
+] }
 
 url = { version = "2.5.7" }
 config = { version = "0.15.16", features = ["yaml"] }
@@ -89,13 +95,15 @@ tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 curve25519-dalek = { version = "4.1.3" }
 borsh = { version = "1.5.7", features = ["derive"] }
 bcs = { version = "0.1.6" }
-sui-types = { package = "sui-sdk-types", version = "0.0.6", features = ["serde"] }
-sui-transaction-builder = { package = "sui-transaction-builder", version = "0.0.6" }
+sui-types = { package = "sui-sdk-types", version = "0.0.7", features = [
+    "serde",
+] }
+sui-transaction-builder = { package = "sui-transaction-builder", version = "0.0.7" }
 k256 = { version = "0.13.4" }
 
 uniffi = { version = "0.29.4" }
 
 alloy-primitives = "1.4.0"
-alloy-sol-types = { version = "1.3.1", features = ["eip712-serde"] }
-alloy-dyn-abi = { version = "1.3.1", features = ["eip712"] }
-alloy-json-abi = { version = "1.3.1" }
+alloy-sol-types = { version = "1.4.0", features = ["eip712-serde"] }
+alloy-dyn-abi = { version = "1.4.0", features = ["eip712"] }
+alloy-json-abi = { version = "1.4.0" }


### PR DESCRIPTION
Bump sui-sdk-types and sui-transaction-builder to 0.0.7, and update alloy-sol-types, alloy-dyn-abi, and alloy-json-abi to 1.4.0. This ensures compatibility with the latest features and bug fixes from these libraries.