### PR TITLE
Fix Polygon POL coingecko mapping id 

### DIFF
--- a/crates/coingecko/src/mapper.rs
+++ b/crates/coingecko/src/mapper.rs
@@ -71,7 +71,7 @@ pub fn get_coingecko_market_id_for_chain(chain: Chain) -> &'static str {
         | Chain::Unichain => "ethereum",
         Chain::SmartChain | Chain::OpBNB => "binancecoin",
         Chain::Solana => "solana",
-        Chain::Polygon => "matic-network",
+        Chain::Polygon => "pol-ex-matic",
         Chain::Thorchain => "thorchain",
         Chain::Cosmos => "cosmos",
         Chain::Osmosis => "osmosis",


### PR DESCRIPTION
https://www.coingecko.com/en/coins/pol-ex-matic

https://www.coingecko.com/en/coins/matic-network redirects to https://www.coingecko.com/en/coins/matic-migrated-to-pol