### PR TITLE
Simplify Dockerfile build and copy steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,9 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked,id=rust-target-core \
-    cargo build --release --bin api --bin daemon
-
-RUN --mount=type=cache,target=/app/target,sharing=locked,id=rust-target-core \
-    mkdir -p /output && \
-    cp /app/target/release/api /output/ && \
-    cp /app/target/release/daemon /output/
+    cargo build --release --bin api --bin daemon && \
+    cp /app/target/release/api /app/api && \
+    cp /app/target/release/daemon /app/daemon
 
 FROM debian:bookworm AS runtime
 WORKDIR /app
@@ -25,8 +22,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /output/api /app/
-COPY --from=builder /output/daemon /app/
+COPY --from=builder /app/api /app/
+COPY --from=builder /app/daemon /app/
 COPY --from=builder /app/Settings.yaml /app/
 
 CMD ["sh", "-c", "/app/${BINARY}"]

--- a/dynode.Dockerfile
+++ b/dynode.Dockerfile
@@ -7,11 +7,8 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked,id=rust-target-dynode \
-    cargo build --release --package dynode
-
-RUN --mount=type=cache,target=/app/target,sharing=locked,id=rust-target-dynode \
-    mkdir -p /output && \
-    cp /app/target/release/dynode /output/
+    cargo build --release --package dynode && \
+    cp /app/target/release/dynode /app/dynode
 
 FROM debian:bookworm AS runtime
 WORKDIR /app
@@ -22,7 +19,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /output/dynode /app/
+COPY --from=builder /app/dynode /app/
 COPY --from=builder /app/apps/dynode/config.yml /app/
 COPY --from=builder /app/apps/dynode/domains.yml /app/
 


### PR DESCRIPTION
Consolidated build and binary copy steps in both Dockerfile and dynode.Dockerfile. Binaries are now copied directly to /app, removing the need for an intermediate /output directory.