### PR TITLE
Refactor EIP712 hashing to use signer crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2850,6 +2850,7 @@ dependencies = [
  "serde_json",
  "serde_serializers",
  "settings",
+ "signer",
  "tokio",
 ]
 

--- a/apps/dynode/src/jsonrpc_types.rs
+++ b/apps/dynode/src/jsonrpc_types.rs
@@ -360,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_batch_positional_mapping() {
-        let calls = vec![
+        let calls = [
             JsonRpcCall {
                 jsonrpc: "2.0".to_string(),
                 method: "method_a".to_string(),

--- a/crates/gem_evm/Cargo.toml
+++ b/crates/gem_evm/Cargo.toml
@@ -16,6 +16,7 @@ serde_serializers = { path = "../serde_serializers" }
 gem_jsonrpc = { path = "../gem_jsonrpc" }
 gem_client = { path = "../gem_client" }
 gem_bsc = { path = "../gem_bsc" }
+signer = { path = "../signer" }
 
 hex = { workspace = true }
 alloy-primitives = { workspace = true }

--- a/crates/gem_evm/src/eip712.rs
+++ b/crates/gem_evm/src/eip712.rs
@@ -1,8 +1,8 @@
-use alloy_dyn_abi::TypedData;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_serializers::deserialize_u64_from_str_or_int;
 use std::collections::HashMap;
+use signer::hash_eip712;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct EIP712Domain {
@@ -74,11 +74,8 @@ pub fn eip712_domain_types() -> Vec<EIP712Type> {
 }
 
 pub fn eip712_hash_message(value: Value) -> Result<Vec<u8>, String> {
-    let typed_data: TypedData = serde_json::from_value(value).map_err(|e| format!("Invalid EIP712 JSON: parse error: {e}"))?;
-    let typed_hash = typed_data
-        .eip712_signing_hash()
-        .map_err(|e| format!("Invalid EIP712 JSON: signing hash error: {e}"))?;
-    Ok(typed_hash.to_vec())
+    let json = serde_json::to_string(&value).map_err(|e| format!("Invalid EIP712 JSON: serialize error: {e}"))?;
+    hash_eip712(&json).map(|digest| digest.to_vec()).map_err(|e| e.to_string())
 }
 
 pub fn parse_eip712_json(value: &Value) -> Result<EIP712Message, String> {

--- a/crates/primitives/src/payment_type.rs
+++ b/crates/primitives/src/payment_type.rs
@@ -6,16 +6,12 @@ use typeshare::typeshare;
 #[derive(Debug, Clone, Serialize, Deserialize, AsRefStr, EnumString, PartialEq, Eq, EnumIter)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
+#[derive(Default)]
 pub enum PaymentType {
+    #[default]
     Card, // debit / credit card
     GooglePay,
     ApplePay,
-}
-
-impl Default for PaymentType {
-    fn default() -> Self {
-        Self::Card
-    }
 }
 
 impl PaymentType {


### PR DESCRIPTION
Replaces EIP712 hashing logic in gem_evm and gemstone with the hash_eip712 function from the signer crate. Updates dependencies and refactors related code and tests for consistency. Also simplifies PaymentType default implementation.