### PR TITLE
Improve error handling and logging in swapper providers

### DIFF
--- a/crates/swapper/src/approval/evm.rs
+++ b/crates/swapper/src/approval/evm.rs
@@ -102,7 +102,8 @@ where
     let permit2_call = EthereumRpc::Call(TransactionObject::new_call(permit2_contract, permit2_data), BlockParameter::Latest);
 
     let result: String = client.request(permit2_call).await.map_err(SwapperError::from)?;
-    let decoded = HexDecode(result).unwrap();
+    let decoded = HexDecode(result)
+        .map_err(|_| SwapperError::ABIError("failed to decode permit2 allowance result".into()))?;
     let allowance_return = IAllowanceTransfer::allowanceCall::abi_decode_returns(&decoded).map_err(SwapperError::from)?;
 
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs();

--- a/crates/swapper/src/thorchain/provider.rs
+++ b/crates/swapper/src/thorchain/provider.rs
@@ -140,11 +140,12 @@ where
 
         let approval: Option<ApprovalData> = {
             if from_asset.use_evm_router() {
+                let router_address = route_data.router_address.clone().ok_or(SwapperError::InvalidRoute)?;
                 let from_amount: U256 = value.to_string().parse().map_err(SwapperError::from)?;
                 check_approval_erc20(
                     quote.request.wallet_address.clone(),
                     from_asset.token_id.clone().unwrap(),
-                    route_data.router_address.clone().unwrap(),
+                    router_address,
                     from_amount,
                     self.rpc_provider.clone(),
                     &from_asset.chain.chain(),


### PR DESCRIPTION
Added debug logging to Across provider's is_supported_pair method and improved error handling in EVM approval and Cetus provider by returning custom errors instead of panicking. Also updated Thorchain provider to handle missing router address gracefully.