### PR TITLE
Improve error handling and data assignment in Sui and NEAR

### DIFF
--- a/crates/gem_sui/src/operations/tx.rs
+++ b/crates/gem_sui/src/operations/tx.rs
@@ -13,7 +13,12 @@ pub fn decode_transaction<T: DeserializeOwned>(tx: &str) -> Result<T, Box<dyn Er
 }
 
 pub fn validate_and_hash(encoded: &str) -> Result<TxOutput, Box<dyn Error + Send + Sync>> {
-    TxOutput::from_tx(&decode_transaction(encoded)?)
+    if encoded.trim().is_empty() {
+        return Err("Missing Sui transaction data".into());
+    }
+
+    let tx = decode_transaction(encoded).map_err(|err| format!("Invalid Sui transaction payload: {err}"))?;
+    TxOutput::from_tx(&tx)
 }
 
 pub fn prefill_tx(ptb: TransactionBuilder) -> Transaction {

--- a/crates/swapper/src/near_intents/provider.rs
+++ b/crates/swapper/src/near_intents/provider.rs
@@ -337,7 +337,12 @@ where
             .build_deposit_data(deposit_memo, from_asset, &quote.request.wallet_address, &deposit_address, &amount_in)
             .await?;
 
-        Ok(SwapperQuoteData::new_tranfer(data.to, data.value, data.memo))
+        let DepositData { to, value, data: payload, memo } = data;
+
+        Ok(SwapperQuoteData {
+            data: payload,
+            ..SwapperQuoteData::new_tranfer(to, value, memo)
+        })
     }
 
     async fn get_swap_result(&self, chain: Chain, deposit_address: &str) -> Result<SwapResult, SwapperError> {


### PR DESCRIPTION
- Adds explicit error messages for empty or invalid Sui transaction payloads in `validate_and_hash`. 
- Updates NEAR provider to correctly assign deposit data payload to `SwapperQuoteData`, ensuring all relevant fields are set.