### PR TITLE
Refactor wei parsing to use BigNumberFormatter

### DIFF
--- a/crates/fiat/src/client.rs
+++ b/crates/fiat/src/client.rs
@@ -407,7 +407,7 @@ mod tests {
         let paybis = FiatQuote::mock("paybis", 0.50, 100.0);
         let banxa = FiatQuote::mock("banxa", 0.40, 100.0);
 
-        let mut quotes = vec![paybis.clone(), moonpay.clone(), banxa.clone(), transak.clone(), mercuryo.clone()];
+        let mut quotes = [paybis.clone(), moonpay.clone(), banxa.clone(), transak.clone(), mercuryo.clone()];
         quotes.sort_by(|a, b| sort_by_crypto_amount(a, b, &providers));
 
         assert_eq!(quotes[0].provider.id, "moonpay");
@@ -430,7 +430,7 @@ mod tests {
         let transak = FiatQuote::mock("transak", 0.60, 100.0);
         let paybis = FiatQuote::mock("paybis", 0.52, 100.0);
 
-        let mut quotes = vec![paybis.clone(), transak.clone(), mercuryo.clone(), moonpay.clone()];
+        let mut quotes = [paybis.clone(), transak.clone(), mercuryo.clone(), moonpay.clone()];
         quotes.sort_by(|a, b| sort_by_crypto_amount(a, b, &providers));
 
         assert_eq!(quotes[0].provider.id, "transak");


### PR DESCRIPTION
Replaces the custom hypercore_wei_from_value function with BigNumberFormatter::value_as_u64 for parsing wei values in stake and unstake actions. Removes the now-unused hypercore_wei_from_value method and updates related tests to use the new parsing approach. Adds a new test to ensure stake actions preserve wei values and nonces.