### PR TITLE
Add Hyperliquid variant to BannerEvent enum

### DIFF
--- a/crates/primitives/src/banner.rs
+++ b/crates/primitives/src/banner.rs
@@ -18,7 +18,7 @@ pub enum BannerEvent {
     ActivateAsset,
     SuspiciousAsset,
     Onboarding,
-    Hyperliquid,
+    TradePerpetuals,
 }
 
 #[typeshare(swift = "Equatable, CaseIterable, Sendable")]


### PR DESCRIPTION
Introduces a new Hyperliquid variant to the BannerEvent enum in banner.rs to support additional banner event types.