### PR TITLE
Remove autoclose_order_type from perpetual structs

### DIFF
--- a/crates/primitives/src/perpetual.rs
+++ b/crates/primitives/src/perpetual.rs
@@ -1,4 +1,4 @@
-use crate::{Asset, AssetId, PerpetualOrderType, PerpetualPosition, PerpetualProvider, UInt64};
+use crate::{Asset, AssetId, PerpetualPosition, PerpetualProvider, UInt64};
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, EnumString};
 use typeshare::typeshare;
@@ -104,7 +104,6 @@ pub struct PerpetualConfirmData {
     pub margin_amount: f64,
     pub take_profit: Option<String>,
     pub stop_loss: Option<String>,
-    pub autoclose_order_type: PerpetualOrderType,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -132,7 +131,6 @@ pub struct TPSLOrderData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_loss: Option<String>,
     pub size: String,
-    pub autoclose_order_type: PerpetualOrderType,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/primitives/src/testkit/perpetual_mock.rs
+++ b/crates/primitives/src/testkit/perpetual_mock.rs
@@ -1,4 +1,4 @@
-use crate::{Asset, Chain, PerpetualConfirmData, PerpetualDirection, PerpetualOrderType};
+use crate::{Asset, Chain, PerpetualConfirmData, PerpetualDirection};
 
 impl PerpetualConfirmData {
     pub fn mock(direction: PerpetualDirection, asset_index: u32, take_profit: Option<String>, stop_loss: Option<String>) -> Self {
@@ -17,7 +17,6 @@ impl PerpetualConfirmData {
             margin_amount: 50.0,
             take_profit,
             stop_loss,
-            autoclose_order_type: PerpetualOrderType::Market,
         }
     }
 }

--- a/gemstone/src/models/transaction.rs
+++ b/gemstone/src/models/transaction.rs
@@ -2,10 +2,10 @@ use crate::models::*;
 use num_bigint::BigInt;
 use primitives::stake_type::{FreezeData, StakeData};
 use primitives::{
-    AccountDataType, Asset, FeeOption, GasPriceType, HyperliquidOrder, PerpetualConfirmData, PerpetualDirection, PerpetualOrderType, PerpetualProvider,
-    PerpetualType, StakeType, TransactionChange, TransactionFee, TransactionInputType, TransactionLoadInput, TransactionLoadMetadata, TransactionMetadata,
-    TransactionPerpetualMetadata, TransactionState, TransactionStateRequest, TransactionType, TransactionUpdate, TransferDataExtra, TransferDataOutputAction,
-    TransferDataOutputType, UInt64, WalletConnectionSessionAppMetadata,
+    AccountDataType, Asset, FeeOption, GasPriceType, HyperliquidOrder, PerpetualConfirmData, PerpetualDirection, PerpetualProvider, PerpetualType, StakeType,
+    TransactionChange, TransactionFee, TransactionInputType, TransactionLoadInput, TransactionLoadMetadata, TransactionMetadata, TransactionPerpetualMetadata,
+    TransactionState, TransactionStateRequest, TransactionType, TransactionUpdate, TransferDataExtra, TransferDataOutputAction, TransferDataOutputType, UInt64,
+    WalletConnectionSessionAppMetadata,
     perpetual::{CancelOrderData, PerpetualModifyConfirmData, PerpetualModifyPositionType, PerpetualReduceData, TPSLOrderData},
 };
 use std::collections::HashMap;
@@ -208,7 +208,6 @@ pub struct PerpetualConfirmData {
     pub margin_amount: f64,
     pub take_profit: Option<String>,
     pub stop_loss: Option<String>,
-    pub autoclose_order_type: PerpetualOrderType,
 }
 
 #[uniffi::remote(Record)]
@@ -223,7 +222,6 @@ pub struct TPSLOrderData {
     pub take_profit: Option<String>,
     pub stop_loss: Option<String>,
     pub size: String,
-    pub autoclose_order_type: PerpetualOrderType,
 }
 
 #[uniffi::remote(Enum)]


### PR DESCRIPTION
Eliminated the autoclose_order_type field from PerpetualConfirmData and TPSLOrderData in both primitives and gemstone models, as well as related logic in core_signer and testkit. This simplifies the perpetual order data structures and their usage.