### PR TITLE
Update alloy dependencies and add audit config

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+ignore = [
+    # ruint::algorithms::div::reciprocal_mg10 OOB; only reachable if low-level algorithms are called directly.
+    # We only use ruint through alloy-primitives higher-level APIs.
+    "RUSTSEC-2025-0137",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,12 +109,12 @@ k256 = { version = "0.13.4", features = ["ecdsa", "sha256"] }
 
 uniffi = { version = "0.30.0" }
 
-alloy-primitives = { version = "1.5.0", features = ["k256"] }
-alloy-sol-types = { version = "1.4.1", features = ["eip712-serde"] }
-alloy-dyn-abi = { version = "1.5.0", features = ["eip712"] }
-alloy-json-abi = { version = "1.4.1" }
+alloy-primitives = { version = "1.5.2", features = ["k256"] }
+alloy-sol-types = { version = "1.5.2", features = ["eip712-serde"] }
+alloy-dyn-abi = { version = "1.5.2", features = ["eip712"] }
+alloy-json-abi = { version = "1.5.2" }
 alloy-signer = { version = "1.2.1" }
-alloy-signer-local = { version = "1.1.3" }
-alloy-network = { version = "1.1.3" }
-alloy-consensus = { version = "1.1.3" }
+alloy-signer-local = { version = "1.2.1" }
+alloy-network = { version = "1.2.1" }
+alloy-consensus = { version = "1.2.1" }
 alloy-rlp = { version = "0.3.12" }

--- a/crates/name_resolver/Cargo.toml
+++ b/crates/name_resolver/Cargo.toml
@@ -6,14 +6,14 @@ version = { workspace = true }
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-reqwest  = { workspace = true }
+reqwest = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
-borsh  = { workspace = true }
+borsh = { workspace = true }
 hex = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
-alloy-ens = { version = "1.1.0" }
+alloy-ens = { version = "1.2.1" }
 gem_client = { path = "../gem_client", features = ["reqwest"] }
 gem_jsonrpc = { path = "../gem_jsonrpc", features = ["client"] }
 idna = { version = "1.1.0" }


### PR DESCRIPTION
- Bump alloy-related dependencies to latest versions in Cargo.toml and name_resolver/Cargo.toml. 
- Add .cargo/audit.toml to ignore a specific RUSTSEC advisory for ruint, which is not directly used. This ensures up-to-date dependencies and clarifies security audit handling.