### PR TITLE
Update rust-embed and refactor test configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6409,9 +6409,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-embed"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",

--- a/crates/gem_rewards/src/risk_scoring/scoring.rs
+++ b/crates/gem_rewards/src/risk_scoring/scoring.rs
@@ -316,8 +316,10 @@ mod tests {
     #[test]
     fn ip_reuse() {
         let input = create_test_input();
-        let mut config = RiskScoreConfig::default();
-        config.max_allowed_score = 40;
+        let config = RiskScoreConfig {
+            max_allowed_score: 40,
+            ..Default::default()
+        };
 
         let existing = create_signal("other_user", "different", "192.168.1.1", "Verizon", "Pixel 8", 2);
         let result = calculate_risk_score(&input, &[existing], 0, 0, &config);
@@ -436,9 +438,11 @@ mod tests {
         let mut input = create_test_input();
         input.ip_isp = "SuspiciousISP Inc".to_string();
         input.ip_abuse_score = 25;
-        let mut config = RiskScoreConfig::default();
-        config.penalty_isps = vec!["SuspiciousISP".to_string()];
-        config.max_allowed_score = 50;
+        let config = RiskScoreConfig {
+            penalty_isps: vec!["SuspiciousISP".to_string()],
+            max_allowed_score: 50,
+            ..Default::default()
+        };
         let result = calculate_risk_score(&input, &[], 0, 0, &config);
 
         assert_eq!(result.breakdown.abuse_score, 25);

--- a/crates/localizer/Cargo.toml
+++ b/crates/localizer/Cargo.toml
@@ -6,4 +6,4 @@ edition = { workspace = true }
 [dependencies]
 i18n-embed = { version = "0.16.0", features = ["fluent-system", "autoreload"] }
 i18n-embed-fl = { version = "0.10.0" }
-rust-embed = { version = "8.9.0" }
+rust-embed = { version = "8.11.0" }

--- a/crates/pricer/src/price_alert_client.rs
+++ b/crates/pricer/src/price_alert_client.rs
@@ -52,13 +52,7 @@ impl PriceAlertRules {
             return None;
         }
 
-        for &milestone in &self.milestones {
-            if price_24h_ago < milestone && current_price >= milestone {
-                return Some(milestone);
-            }
-        }
-
-        None
+        self.milestones.iter().find(|&&milestone| price_24h_ago < milestone && current_price >= milestone).copied()
     }
 }
 


### PR DESCRIPTION
Bump rust-embed from 8.9.0 to 8.11.0 in localizer crate and Cargo.lock. Refactor test configuration initialization in scoring.rs to use struct update syntax for clarity. Simplify milestone detection logic in price_alert_client.rs using iterator methods.