### PR TITLE
Add PerpetualPortfolioChartType enum

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -204,7 +204,7 @@ pub use self::perpetual_provider::PerpetualProvider;
 pub mod perpetual_position;
 pub use self::perpetual_position::{PerpetualMarginType, PerpetualOrderType, PerpetualPosition, PerpetualTriggerOrder};
 pub mod portfolio;
-pub use self::portfolio::{PerpetualAccountSummary, PerpetualPortfolio, PerpetualPortfolioTimeframeData};
+pub use self::portfolio::{PerpetualAccountSummary, PerpetualPortfolio, PerpetualPortfolioChartType, PerpetualPortfolioTimeframeData};
 pub use chrono;
 pub mod tpsl_type;
 pub use self::tpsl_type::TpslType;

--- a/crates/primitives/src/portfolio.rs
+++ b/crates/primitives/src/portfolio.rs
@@ -3,6 +3,14 @@ use typeshare::typeshare;
 
 use crate::chart::ChartDateValue;
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[typeshare(swift = "Equatable, Sendable, CaseIterable, Identifiable")]
+#[serde(rename_all = "camelCase")]
+pub enum PerpetualPortfolioChartType {
+    Value,
+    Pnl,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[typeshare(swift = "Equatable, Sendable, Hashable")]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Introduces the PerpetualPortfolioChartType enum to represent chart types for perpetual portfolios. Updates the lib.rs export to include this new type.