### PR TITLE
Add coin field to ChartCandleStick for proper candle filtering

### DIFF
--- a/crates/gem_hypercore/src/models/candlestick.rs
+++ b/crates/gem_hypercore/src/models/candlestick.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use primitives::chart::ChartCandleStick;
+use primitives::chart::{ChartCandleStick, ChartCandleUpdate};
 use serde::{Deserialize, Serialize};
 
 use crate::models::UInt64;
@@ -7,6 +7,7 @@ use crate::models::UInt64;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Candlestick {
     pub t: UInt64, // Open time (timestamp in milliseconds)
+    pub s: String, // Symbol (coin)
     pub i: String, // Interval
     pub o: String, // Open price
     pub h: String, // High price
@@ -15,16 +16,25 @@ pub struct Candlestick {
     pub v: String, // Volume
 }
 
-impl From<Candlestick> for ChartCandleStick {
-    fn from(candlestick: Candlestick) -> Self {
+impl From<&Candlestick> for ChartCandleStick {
+    fn from(c: &Candlestick) -> Self {
         ChartCandleStick {
-            date: DateTime::from_timestamp(candlestick.t as i64 / 1000, 0).unwrap_or(Utc::now()),
-            interval: candlestick.i,
-            open: candlestick.o.parse().unwrap_or(0.0),
-            high: candlestick.h.parse().unwrap_or(0.0),
-            low: candlestick.l.parse().unwrap_or(0.0),
-            close: candlestick.c.parse().unwrap_or(0.0),
-            volume: candlestick.v.parse().unwrap_or(0.0),
+            date: DateTime::from_timestamp(c.t as i64 / 1000, 0).unwrap_or(Utc::now()),
+            open: c.o.parse().unwrap_or(0.0),
+            high: c.h.parse().unwrap_or(0.0),
+            low: c.l.parse().unwrap_or(0.0),
+            close: c.c.parse().unwrap_or(0.0),
+            volume: c.v.parse().unwrap_or(0.0),
+        }
+    }
+}
+
+impl From<Candlestick> for ChartCandleUpdate {
+    fn from(c: Candlestick) -> Self {
+        ChartCandleUpdate {
+            coin: c.s.clone(),
+            interval: c.i.clone(),
+            candle: ChartCandleStick::from(&c),
         }
     }
 }

--- a/crates/gem_hypercore/src/models/websocket.rs
+++ b/crates/gem_hypercore/src/models/websocket.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use primitives::PerpetualPosition;
-use primitives::chart::ChartCandleStick;
+use primitives::chart::ChartCandleUpdate;
 use primitives::perpetual::PerpetualBalance;
 use serde::Deserialize;
 
@@ -70,7 +70,7 @@ pub struct PositionsDiff {
 pub enum HyperliquidSocketMessage {
     ClearinghouseState { balance: PerpetualBalance, positions: Vec<PerpetualPosition> },
     OpenOrders { orders: Vec<OpenOrder> },
-    Candle { candle: ChartCandleStick },
+    Candle { candle: ChartCandleUpdate },
     AllMids { prices: HashMap<String, f64> },
     SubscriptionResponse { subscription_type: String },
     Unknown,

--- a/crates/gem_hypercore/src/provider/perpetual_mapper.rs
+++ b/crates/gem_hypercore/src/provider/perpetual_mapper.rs
@@ -142,7 +142,7 @@ pub fn map_perpetuals_data(metadata: HypercoreMetadataResponse) -> Vec<Perpetual
 }
 
 pub fn map_candlesticks(candlesticks: Vec<Candlestick>) -> Vec<ChartCandleStick> {
-    candlesticks.into_iter().map(|c| c.into()).collect()
+    candlesticks.iter().map(ChartCandleStick::from).collect()
 }
 
 pub fn map_account_summary(positions: &AssetPositions) -> PerpetualAccountSummary {
@@ -334,6 +334,7 @@ mod tests {
         let candlesticks = vec![
             Candlestick {
                 t: 1640995200000u64, // 2022-01-01 00:00:00 UTC
+                s: "BTC".to_string(),
                 i: "1h".to_string(),
                 o: "50000.0".to_string(),
                 h: "51000.0".to_string(),
@@ -343,6 +344,7 @@ mod tests {
             },
             Candlestick {
                 t: 1640998800000u64, // 2022-01-01 01:00:00 UTC
+                s: "BTC".to_string(),
                 i: "1h".to_string(),
                 o: "50500.0".to_string(),
                 h: "52000.0".to_string(),

--- a/crates/gem_hypercore/src/provider/websocket_mapper.rs
+++ b/crates/gem_hypercore/src/provider/websocket_mapper.rs
@@ -98,16 +98,17 @@ mod tests {
     #[test]
     fn test_parse_candle() {
         let json = include_bytes!("../../testdata/ws_candle.json");
-        let HyperliquidSocketMessage::Candle { candle } = parse_websocket_data(json).unwrap() else {
+        let HyperliquidSocketMessage::Candle { candle: update } = parse_websocket_data(json).unwrap() else {
             panic!("expected Candle");
         };
 
-        assert_eq!(candle.interval, "1h");
-        assert_eq!(candle.open, 3300.5);
-        assert_eq!(candle.close, 3321.1);
-        assert_eq!(candle.high, 3345.0);
-        assert_eq!(candle.low, 3290.2);
-        assert_eq!(candle.volume, 12450.8);
+        assert_eq!(update.coin, "ETH");
+        assert_eq!(update.interval, "1h");
+        assert_eq!(update.candle.open, 3300.5);
+        assert_eq!(update.candle.close, 3321.1);
+        assert_eq!(update.candle.high, 3345.0);
+        assert_eq!(update.candle.low, 3290.2);
+        assert_eq!(update.candle.volume, 12450.8);
     }
 
     #[test]

--- a/crates/primitives/src/chart.rs
+++ b/crates/primitives/src/chart.rs
@@ -7,12 +7,20 @@ use typeshare::typeshare;
 #[serde(rename_all = "camelCase")]
 pub struct ChartCandleStick {
     pub date: DateTime<Utc>,
-    pub interval: String,
     pub open: f64,
     pub high: f64,
     pub low: f64,
     pub close: f64,
     pub volume: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[typeshare(swift = "Equatable, Sendable")]
+#[serde(rename_all = "camelCase")]
+pub struct ChartCandleUpdate {
+    pub coin: String,
+    pub interval: String,
+    pub candle: ChartCandleStick,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/gemstone/src/models/perpetual.rs
+++ b/gemstone/src/models/perpetual.rs
@@ -5,7 +5,7 @@ use gem_hypercore::models::order::OpenOrder;
 use gem_hypercore::models::websocket::{HyperliquidSocketMessage, PositionsDiff};
 use primitives::{
     Asset, AssetId, PerpetualDirection, PerpetualMarginType, PerpetualOrderType, PerpetualPosition, PerpetualProvider, PerpetualTriggerOrder,
-    chart::{ChartCandleStick, ChartDateValue},
+    chart::{ChartCandleStick, ChartCandleUpdate, ChartDateValue},
     perpetual::{Perpetual, PerpetualBalance, PerpetualData, PerpetualMetadata, PerpetualPositionsSummary},
 };
 
@@ -19,6 +19,7 @@ pub type GemPerpetualPosition = PerpetualPosition;
 pub type GemPerpetual = Perpetual;
 pub type GemPerpetualMetadata = PerpetualMetadata;
 pub type GemChartCandleStick = ChartCandleStick;
+pub type GemChartCandleUpdate = ChartCandleUpdate;
 pub type GemChartDateValue = ChartDateValue;
 pub type GemPerpetualData = PerpetualData;
 
@@ -105,12 +106,18 @@ pub struct GemPerpetualMetadata {
 #[uniffi::remote(Record)]
 pub struct GemChartCandleStick {
     pub date: DateTime<Utc>,
-    pub interval: String,
     pub open: f64,
     pub high: f64,
     pub low: f64,
     pub close: f64,
     pub volume: f64,
+}
+
+#[uniffi::remote(Record)]
+pub struct GemChartCandleUpdate {
+    pub coin: String,
+    pub interval: String,
+    pub candle: ChartCandleStick,
 }
 
 #[uniffi::remote(Record)]
@@ -141,7 +148,7 @@ pub type GemHyperliquidSocketMessage = HyperliquidSocketMessage;
 pub enum GemHyperliquidSocketMessage {
     ClearinghouseState { balance: PerpetualBalance, positions: Vec<PerpetualPosition> },
     OpenOrders { orders: Vec<GemHyperliquidOpenOrder> },
-    Candle { candle: ChartCandleStick },
+    Candle { candle: ChartCandleUpdate },
     AllMids { prices: HashMap<String, f64> },
     SubscriptionResponse { subscription_type: String },
     Unknown,


### PR DESCRIPTION
When multiple perpetual screens are open, candle updates from one asset were incorrectly applied to another asset's chart. This adds the coin identifier to ChartCandleStick so consumers can validate which asset a candle belongs to.