### PR TITLE
Update Jupiter v6 and remove auto-slippage

### DIFF
--- a/crates/swapper/src/config.rs
+++ b/crates/swapper/src/config.rs
@@ -138,7 +138,7 @@ pub fn get_default_slippage(chain: &Chain) -> SwapperSlippage {
     match chain {
         Chain::Solana => SwapperSlippage {
             bps: DEFAULT_SLIPPAGE_BPS * 3,
-            mode: SwapperSlippageMode::Auto,
+            mode: SwapperSlippageMode::Exact,
         },
         _ => SwapperSlippage {
             bps: DEFAULT_SLIPPAGE_BPS,

--- a/crates/swapper/src/jupiter/model.rs
+++ b/crates/swapper/src/jupiter/model.rs
@@ -8,8 +8,7 @@ pub struct QuoteRequest {
     pub amount: String,
     pub slippage_bps: u32,
     pub platform_fee_bps: u32,
-    pub auto_slippage: bool,
-    pub max_auto_slippage_bps: u32,
+    pub instruction_version: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,12 +21,12 @@ pub struct QuoteResponse {
     pub other_amount_threshold: String,
     pub swap_mode: String,
     pub slippage_bps: u32,
-    pub computed_auto_slippage: Option<u32>,
     pub platform_fee: Value,
     pub price_impact_pct: String,
     pub route_plan: Value,
     pub context_slot: i64,
     pub time_taken: f64,
+    pub instruction_version: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,18 +44,10 @@ pub struct SimulationError {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DynamicSlippage {
-    pub max_bps: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct QuoteDataRequest {
     pub user_public_key: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub fee_account: String,
     pub quote_response: QuoteResponse,
     pub prioritization_fee_lamports: i64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub dynamic_slippage: Option<DynamicSlippage>,
 }


### PR DESCRIPTION
Fixes https://github.com/gemwalletcom/core/issues/947

Update models and provider to align with Jupiter v6: 
- replace auto_slippage/max_auto_slippage_bps with an instruction_version field in QuoteRequest/QuoteResponse
- remove DynamicSlippage and dynamic_slippage usage, and pass a constant INSTRUCTION_VERSION ("V2") when requesting quotes. 
- Adjust provider logic to use swap_quote.slippage_bps directly and remove computed auto-slippage handling. 
- Also change Solana default slippage mode to Exact (with increased bps) in config.

Tested txs:
 - SOL -> INU https://solscan.io/tx/NpmseffBmytLoXZrPmfX98Ho6BYSbzYWDYknQtVWZEVsgHEVUG6h6k2ccUCthxxNpTHq9qrAXTft4JXpA2ajPz4
 - INU -> USDC https://solscan.io/tx/qzGfecVS8BUx8xSjcVK8h744ENS6srBT9xMH5WAmePSXEhbyVYyDNZxA4zFVq9ygPRAFgZitCqVRadEs33RjrKy