### PR TITLE
Fix panic_bounds_check in fetch_smartchain_staking_state

### DIFF
--- a/crates/gem_evm/src/provider/staking_smartchain.rs
+++ b/crates/gem_evm/src/provider/staking_smartchain.rs
@@ -141,8 +141,9 @@ impl<C: Client + Clone> EthereumClient<C> {
             ),
         ];
 
+        let call_count = calls.len();
         let results: Vec<String> = self.client.batch_call::<String>(calls).await?.extract();
-        if results.len() < 2 {
+        if results.len() < call_count {
             return Err("Expected 2 RPC responses for staking state".into());
         }
 


### PR DESCRIPTION
Add bounds check after .extract() which silently drops failed RPC responses, preventing index-out-of-bounds panic when batch call partially fails.