### PR TITLE
Change panic mode to default/unwind

### DIFF
--- a/gemstone/.cargo/config.toml
+++ b/gemstone/.cargo/config.toml
@@ -8,4 +8,3 @@ strip = true
 codegen-units = 1
 lto = "fat"
 opt-level = "z"
-panic = "abort"


### PR DESCRIPTION
Delete the explicit panic = "abort" setting from gemstone/.cargo/config.toml so the workspace will use Rust's default panic strategy (typically unwind). This improves compatibility with tests, debugging and libraries that require unwinding.