### PR TITLE
Expose swap provider selection method and refactor fetch quote

### DIFF
--- a/crates/swapper/src/swapper.rs
+++ b/crates/swapper/src/swapper.rs
@@ -188,7 +188,7 @@ impl GemSwapper {
         Ok(providers)
     }
 
-    pub async fn fetch_quote(&self, request: &QuoteRequest) -> Result<Vec<Quote>, SwapperError> {
+    pub async fn get_quote(&self, request: &QuoteRequest) -> Result<Vec<Quote>, SwapperError> {
         let provider_ids: BTreeSet<_> = self.get_providers_for_request(request)?.into_iter().map(|p| p.id).collect();
         let providers = self.swappers.iter().filter(|x| provider_ids.contains(&x.provider().id)).collect::<Vec<_>>();
 
@@ -230,7 +230,7 @@ impl GemSwapper {
         provider.fetch_permit2_for_quote(quote).await
     }
 
-    pub async fn fetch_quote_data(&self, quote: &Quote, data: FetchQuoteData) -> Result<SwapperQuoteData, SwapperError> {
+    pub async fn get_quote_data(&self, quote: &Quote, data: FetchQuoteData) -> Result<SwapperQuoteData, SwapperError> {
         let provider = self.get_swapper_by_provider(&quote.data.provider.id)?;
         let mut quote_data = provider.fetch_quote_data(quote, data).await?;
         if let Some(gas_limit) = quote_data.gas_limit.take() {
@@ -447,7 +447,7 @@ mod tests {
                 Box::new(MockSwapper::new(SwapperProvider::Jupiter, || Err(SwapperError::NoQuoteAvailable))),
             ],
         };
-        assert_eq!(gem_swapper.fetch_quote(&request).await, Err(SwapperError::InputAmountError { min_amount: None }));
+        assert_eq!(gem_swapper.get_quote(&request).await, Err(SwapperError::InputAmountError { min_amount: None }));
 
         let gem_swapper = GemSwapper {
             rpc_provider: Arc::new(NativeProvider::default()),
@@ -470,7 +470,7 @@ mod tests {
             ],
         };
         assert_eq!(
-            gem_swapper.fetch_quote(&request).await,
+            gem_swapper.get_quote(&request).await,
             Err(SwapperError::InputAmountError {
                 min_amount: Some("1390400".into())
             })

--- a/gemstone/src/gem_swapper/mod.rs
+++ b/gemstone/src/gem_swapper/mod.rs
@@ -41,8 +41,8 @@ impl GemSwapper {
         self.inner.get_providers_for_request(request)
     }
 
-    pub async fn fetch_quote(&self, request: &SwapperQuoteRequest) -> Result<Vec<SwapperQuote>, SwapperError> {
-        self.inner.fetch_quote(request).await
+    pub async fn get_quote(&self, request: &SwapperQuoteRequest) -> Result<Vec<SwapperQuote>, SwapperError> {
+        self.inner.get_quote(request).await
     }
 
     pub async fn fetch_quote_by_provider(&self, provider: SwapperProvider, request: SwapperQuoteRequest) -> Result<SwapperQuote, SwapperError> {
@@ -53,8 +53,8 @@ impl GemSwapper {
         self.inner.fetch_permit2_for_quote(quote).await
     }
 
-    pub async fn fetch_quote_data(&self, quote: &SwapperQuote, data: FetchQuoteData) -> Result<GemSwapQuoteData, SwapperError> {
-        self.inner.fetch_quote_data(quote, data).await
+    pub async fn get_quote_data(&self, quote: &SwapperQuote, data: FetchQuoteData) -> Result<GemSwapQuoteData, SwapperError> {
+        self.inner.get_quote_data(quote, data).await
     }
 
     pub async fn get_swap_result(&self, chain: Chain, provider: SwapperProvider, transaction_hash: &str) -> Result<SwapperSwapResult, SwapperError> {

--- a/gemstone/tests/ios/GemTest/GemTest/ViewModel.swift
+++ b/gemstone/tests/ios/GemTest/GemTest/ViewModel.swift
@@ -9,7 +9,7 @@ public struct ViewModel: Sendable {
 
     public func fetchQuote(_ request: SwapperQuoteRequest) async throws {
         let swapper = GemSwapper(rpcProvider: self.provider)
-        var quotes = try await swapper.fetchQuote(request: request)
+        var quotes = try await swapper.getQuote(request: request)
         quotes = quotes.sorted(by: { lhs, rhs in
             BigInt(lhs.toValue)! > BigInt(rhs.toValue)!
         })
@@ -43,7 +43,7 @@ public struct ViewModel: Sendable {
             print("<== permit2", permit2)
         }
 
-        let data = try await swapper.fetchQuoteData(quote: quote, data: .none)
+        let data = try await swapper.getQuoteData(quote: quote, data: .none)
         print("<== fetchQuoteData:\n", data)
     }
 


### PR DESCRIPTION
Prepare for stream quotes, it extracts and exposes provider filtering logic into `get_providers_for_request` (returns Vec<ProviderType>) in crates/swapper.

Swift / iOS

```swift
func streamQuotes(wallet: Wallet, fromAsset: Asset, toAsset: Asset, amount: BigInt, useMaxAmount: Bool)
  -> AsyncStream<Result<SwapperQuote, Error>> {
      AsyncStream { continuation in
          Task {
              let providers = try swapService.getProvidersForQuote(...)

              await withTaskGroup(of: Result<SwapperQuote, Error>?.self) { group in
                  for provider in providers {
                      group.addTask {
                          let quote = try await swapService.getQuoteByProvider(provider: provider.id, ...)
                          return .success(quote)
                      }
                  }
                  for await result in group {
                      continuation.yield(result)
                  }
              }
              continuation.finish()
          }
      }
  }
```
Kotlin / Android

```kotlin
fun streamQuotes(wallet: Wallet, fromAsset: Asset, toAsset: Asset, amount: BigInt, useMaxAmount:
  Boolean): Flow<Result<SwapperQuote>> = channelFlow {
      val providers = swapService.getProvidersForQuote(...)

      coroutineScope {
          for (provider in providers) {
              launch {
                  val quote = swapService.getQuoteByProvider(provider = provider.id, ...)
                  send(Result.success(quote))
              }
          }
      }
  }
```