### PR TITLE
Update Rust workspace resolver and rustfmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/gemwalletcom/core"
 documentation = "https://github.com/gemwalletcom"
 
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "apps/api",
     "apps/daemon",

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 edition = "2024"
+style_edition = "2024"
 max_width = 180
 reorder_imports = true

--- a/skills/code-style.md
+++ b/skills/code-style.md
@@ -4,7 +4,7 @@ Follow the existing code style patterns unless explicitly asked to change.
 
 ## Formatting
 
-- Line length: 160 characters maximum (configured in `rustfmt.toml`)
+- Line length: 180 characters maximum (configured in `rustfmt.toml`)
 - Indentation: 4 spaces (Rust standard)
 - Imports: Automatically reordered with rustfmt
 - Only format files you modified: `rustfmt --edition 2024 <file1> <file2> ...`


### PR DESCRIPTION
- Bump Cargo workspace resolver to 3 and align formatting settings: add style_edition = "2024"
- Update skills/code-style.md to reflect the new 180-character line length.