### PR TITLE
Add PancakeSwap V3 deployment for ZkSync / Monad

### DIFF
--- a/crates/gem_evm/src/uniswap/deployment/v3.rs
+++ b/crates/gem_evm/src/uniswap/deployment/v3.rs
@@ -129,7 +129,7 @@ pub fn get_pancakeswap_router_deployment_by_chain(chain: &Chain) -> Option<V3Dep
         Chain::Monad => Some(V3Deployment {
             quoter_v2: "0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997",
             universal_router: "0x23682a588CF2601ACa977dF200938634c9F7d552",
-            permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+            permit2: "0xDca6Dd86A5E305dB99A15eaEB2a6ecfc7F579778",
         }),
         _ => None,
     }


### PR DESCRIPTION
Add ZkSync and Momad to PancakeSwap router deployment with QuoterV2, Universal Router and Permit2 addresses.

ZkSync txs:
- ETH -> USDC https://explorer.zksync.io/tx/0xbd18976f7d5b0bc37375ca6027a256a63adf9c578d001111caf7d9107e058232
- USDC -> ETH https://explorer.zksync.io/tx/0xc6cfa078f12a995875e53cd66aed4981d9f63013b9c345d04aedce204f1fcbca

Monad txs:
- MON -> USDC https://monadscan.com/tx/0xbcead1e6d7ecb8fa3d5a0d05decba2cbfb7f4f2b146a0772a0c0264b57276524
- USDC -> MON https://monadscan.com/tx/0x5ee6f85625f3394cd81807c718b6e894a1e91a2ee14ddc5cb18996cff04be56f
