### PR TITLE
Provide staking metadata for Tron non-stakers

### DIFF
--- a/crates/gem_tron/src/provider/balances.rs
+++ b/crates/gem_tron/src/provider/balances.rs
@@ -1,14 +1,14 @@
 use async_trait::async_trait;
 use chain_traits::ChainBalances;
 use futures::future::join_all;
-use num_bigint::BigUint;
 use std::error::Error;
 
 use gem_client::Client;
+use num_bigint::BigUint;
 use primitives::{AssetBalance, AssetId, Chain, asset_balance::BalanceMetadata};
 
 use crate::{
-    provider::balances_mapper::{format_address_parameter, map_coin_balance, map_metadata_from_usage, map_staking_balance, map_token_balance},
+    provider::balances_mapper::{format_address_parameter, map_balance_staking, map_coin_balance, map_token_balance},
     rpc::{client::TronClient, trongrid::mapper::TronGridMapper},
 };
 
@@ -39,20 +39,8 @@ impl<C: Client> ChainBalances for TronClient<C> {
     async fn get_balance_staking(&self, address: String) -> Result<Option<AssetBalance>, Box<dyn Error + Sync + Send>> {
         let account = self.get_account(&address).await?;
         if let Some(address) = account.clone().address {
-            if account.is_staking() {
-                let (reward, usage) = futures::try_join!(self.get_reward(&address), self.get_account_usage(&address))?;
-                Ok(Some(map_staking_balance(&account, &reward, &usage)?))
-            } else {
-                let usage = self.get_account_usage(&address).await?;
-                let metadata = map_metadata_from_usage(&usage, 0);
-                Ok(Some(AssetBalance::new_staking_with_metadata(
-                    AssetId::from_chain(Chain::Tron),
-                    BigUint::from(0u32),
-                    BigUint::from(0u32),
-                    BigUint::from(0u32),
-                    metadata,
-                )))
-            }
+            let (reward, usage) = futures::try_join!(self.get_reward(&address), self.get_account_usage(&address))?;
+            Ok(Some(map_balance_staking(&account, &reward, &usage)?))
         } else {
             Ok(Some(AssetBalance::new_staking_with_metadata(
                 AssetId::from_chain(Chain::Tron),

--- a/crates/gem_tron/src/provider/balances_mapper.rs
+++ b/crates/gem_tron/src/provider/balances_mapper.rs
@@ -66,6 +66,25 @@ pub fn map_staking_balance(account: &TronAccount, reward: &TronReward, usage: &T
     ))
 }
 
+pub fn map_balance_staking(account: &TronAccount, reward: &TronReward, usage: &TronAccountUsage) -> Result<AssetBalance, Box<dyn Error + Sync + Send>> {
+    if account.is_staking() {
+        map_staking_balance(account, reward, usage)
+    } else {
+        let metadata = map_metadata_from_usage(usage, 0);
+        Ok(AssetBalance::new_balance(
+            AssetId::from_chain(Chain::Tron),
+            new_stake_balance(
+                BigUint::from(0u32),
+                BigUint::from(0u32),
+                BigUint::from(0u32),
+                BigUint::from(0u32),
+                BigUint::from(0u32),
+                metadata,
+            ),
+        ))
+    }
+}
+
 pub(crate) fn format_address_parameter(address: &str) -> Result<String, Box<dyn Error + Sync + Send>> {
     let owner_bytes = bs58::decode(address).into_vec().map_err(|e| format!("Invalid owner address {}: {}", address, e))?;
 
@@ -379,6 +398,35 @@ mod tests {
         assert_eq!(metadata.energy_total, 0);
         assert_eq!(metadata.bandwidth_available, 0);
         assert_eq!(metadata.bandwidth_total, 0);
+    }
+
+    #[test]
+    fn test_map_balance_staking_non_staker() {
+        let account = TronAccount {
+            balance: Some(1000),
+            address: Some("TEB39Rt69QkgD1BKhqaRNqGxfQzCarkRCb".to_string()),
+            owner_permission: None,
+            active_permission: None,
+            votes: None,
+            frozen_v2: None,
+            unfrozen_v2: None,
+        };
+        let reward = TronReward { reward: 0 };
+        let usage = TronAccountUsage {
+            energy_limit: 0,
+            energy_used: 0,
+            free_net_limit: 600,
+            free_net_used: 100,
+            net_used: 0,
+            net_limit: 0,
+        };
+
+        let balance = map_balance_staking(&account, &reward, &usage).unwrap();
+        let metadata = balance.balance.metadata.unwrap();
+
+        assert_eq!(metadata.bandwidth_available, 500);
+        assert_eq!(metadata.bandwidth_total, 600);
+        assert_eq!(metadata.votes, 0);
     }
 
     #[test]


### PR DESCRIPTION
Fix Tron bandwidth showing 0/0 for non-staking accounts.

Now get_account_usage is called for all activated accounts. For non-staking ones, the usage is mapped via map_metadata_from_usage with votes=0, so bandwidth correctly shows 600/600.