### PR TITLE
Get validators from delegation, including jailed

### DIFF
--- a/crates/gem_cosmos/src/provider/staking.rs
+++ b/crates/gem_cosmos/src/provider/staking.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use chain_traits::ChainStaking;
 use futures::try_join;
+use std::collections::HashMap;
 use std::error::Error;
 
 use gem_client::Client;
@@ -49,14 +50,24 @@ impl<C: Client> ChainStaking for CosmosClient<C> {
         match chain {
             CosmosChain::Noble | CosmosChain::Thorchain => Ok(vec![]),
             CosmosChain::Cosmos | CosmosChain::Injective | CosmosChain::Osmosis | CosmosChain::Celestia | CosmosChain::Sei => {
-                let (active_delegations, unbonding, rewards, validators) = try_join!(
+                let (active_delegations, unbonding, rewards, validators, delegation_validators) = try_join!(
                     self.get_delegations(&address),
                     self.get_unbonding_delegations(&address),
                     self.get_delegation_rewards(&address),
+                    self.get_validators(),
                     self.get_delegations_validators(&address),
                 )?;
 
-                Ok(map_staking_delegations(active_delegations, unbonding, rewards, validators.validators, chain, denom))
+                let all_validators: Vec<_> = delegation_validators
+                    .validators
+                    .into_iter()
+                    .chain(validators.validators)
+                    .map(|v| (v.operator_address.clone(), v))
+                    .collect::<HashMap<_, _>>()
+                    .into_values()
+                    .collect();
+
+                Ok(map_staking_delegations(active_delegations, unbonding, rewards, all_validators, chain, denom))
             }
         }
     }

--- a/crates/gem_cosmos/src/rpc/client.rs
+++ b/crates/gem_cosmos/src/rpc/client.rs
@@ -81,7 +81,7 @@ impl<C: Client> CosmosClient<C> {
     }
 
     pub async fn get_delegations_validators(&self, address: &str) -> Result<ValidatorsResponse, Box<dyn Error + Send + Sync>> {
-        Ok(self.client.get(&format!("/cosmos/staking/v1beta1/delegators/{address}/validators?pagination.limit=100")).await?)
+        Ok(self.client.get(&format!("/cosmos/staking/v1beta1/delegators/{address}/validators")).await?)
     }
 
     pub async fn get_staking_pool(&self) -> Result<StakingPoolResponse, Box<dyn Error + Send + Sync>> {


### PR DESCRIPTION
`self.get_validators()` only query bonded validators, if user delegated to a validator and it becomes inactive, the delegation will be gone

<img width="45%" alt="simulator_screenshot_6F4A7D99-38D1-46BA-8D2F-A6A3E4389B55" src="https://github.com/user-attachments/assets/c6f0ba47-7665-4432-8c3c-efbf4b428cb4" />
