### PR TITLE
Make secp256k1 sign_digest chain-agnostic, add sign_eth_digest

### DIFF
--- a/crates/gem_bitcoin/src/signer/signature.rs
+++ b/crates/gem_bitcoin/src/signer/signature.rs
@@ -1,10 +1,8 @@
 use primitives::SignerError;
-use signer::{SignatureScheme, Signer};
+use signer::{RECOVERY_ID_INDEX, SIGNATURE_LENGTH, SignatureScheme, Signer};
 
 use super::types::{BitcoinSignDataResponse, BitcoinSignMessageData};
 
-const SIGNATURE_LENGTH: usize = 65;
-const RECOVERY_ID_INDEX: usize = SIGNATURE_LENGTH - 1;
 const BIP137_P2WPKH_BASE: u8 = 39;
 
 pub fn sign_personal(data: &[u8], private_key: &[u8]) -> Result<BitcoinSignDataResponse, SignerError> {
@@ -32,9 +30,17 @@ mod tests {
     fn test_sign_bitcoin_personal() {
         let data = BitcoinSignMessageData::new("Hello Bitcoin".to_string(), "bc1qtest".to_string()).to_bytes();
         let private_key = hex::decode("1e9d38b5274152a78dff1a86fa464ceadc1f4238ca2c17060c3c507349424a34").unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&sign_personal(&data, &private_key).unwrap().to_json().unwrap()).unwrap();
+        let result = sign_personal(&data, &private_key).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&result.to_json().unwrap()).unwrap();
         assert_eq!(parsed["address"], "bc1qtest");
-        assert!(!parsed["signature"].as_str().unwrap().is_empty());
+
+        let sig_hex = parsed["signature"].as_str().unwrap();
+        let sig_bytes = hex::decode(sig_hex).unwrap();
+        assert_eq!(sig_bytes.len(), SIGNATURE_LENGTH);
+
+        let header = sig_bytes[0];
+        assert!(header == BIP137_P2WPKH_BASE || header == BIP137_P2WPKH_BASE + 1, "unexpected BIP-137 header: {header}");
     }
 
     #[test]

--- a/crates/gem_evm/src/lib.rs
+++ b/crates/gem_evm/src/lib.rs
@@ -42,9 +42,6 @@ pub mod provider;
 pub mod testkit;
 
 pub const ETHEREUM_MESSAGE_PREFIX: &str = "\x19Ethereum Signed Message:\n";
-pub const SIGNATURE_LENGTH: usize = 65;
-pub const RECOVERY_ID_INDEX: usize = SIGNATURE_LENGTH - 1;
-pub const ETHEREUM_RECOVERY_ID_OFFSET: u8 = 27;
 
 pub use address::ethereum_address_checksum;
 pub use eip712::{EIP712Domain, EIP712Field, EIP712Type, EIP712TypedValue, eip712_domain_types};

--- a/crates/gem_tron/src/signer/chain_signer.rs
+++ b/crates/gem_tron/src/signer/chain_signer.rs
@@ -1,7 +1,7 @@
 use gem_hash::sha2::sha256;
 use primitives::{ChainSigner, SignerError, SignerInput, TransferDataOutputType, hex::decode_hex};
 use serde_json::Value;
-use signer::{SignatureScheme, Signer};
+use signer::Signer;
 
 enum PayloadFormat {
     V1,
@@ -70,7 +70,7 @@ impl ChainSigner for TronChainSigner {
         let payload = TronPayload::parse(input)?;
         let raw_bytes = decode_hex(payload.raw_data_hex()?)?;
         let digest = sha256(&raw_bytes);
-        let signature = Signer::sign_digest(SignatureScheme::Secp256k1, digest.to_vec(), private_key.to_vec()).map_err(|e| SignerError::signing_error(e.to_string()))?;
+        let signature = Signer::sign_eth_digest(&digest, private_key).map_err(|e| SignerError::signing_error(e.to_string()))?;
         let signature_hex = hex::encode(signature);
 
         match payload.output_type {

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -3,12 +3,16 @@ mod ed25519;
 mod eip712;
 mod secp256k1;
 
+#[cfg(test)]
+pub(crate) mod testkit {
+    pub const TEST_PRIVATE_KEY: &str = "1e9d38b5274152a78dff1a86fa464ceadc1f4238ca2c17060c3c507349424a34";
+}
+
 use ed25519_dalek::Signer as DalekSigner;
 use zeroize::Zeroizing;
 
 use crate::ed25519::{sign_digest as sign_ed25519_digest, signing_key_from_bytes};
-pub use crate::secp256k1::public_key_from_private as secp256k1_public_key;
-use crate::secp256k1::sign_digest as sign_secp256k1_digest;
+pub use crate::secp256k1::{RECOVERY_ID_INDEX, SIGNATURE_LENGTH, apply_eth_recovery_id, public_key_from_private as secp256k1_public_key};
 
 pub use decode::{decode_private_key, encode_private_key, supports_private_key_import};
 pub use eip712::hash_typed_data as hash_eip712;
@@ -28,8 +32,14 @@ impl Signer {
         let private_key = Zeroizing::new(private_key);
         match scheme {
             SignatureScheme::Ed25519 => Ok(sign_ed25519_digest(&digest, &private_key)?.to_bytes().to_vec()),
-            SignatureScheme::Secp256k1 => sign_secp256k1_digest(&digest, &private_key),
+            SignatureScheme::Secp256k1 => secp256k1::sign_digest_append_recovery(&digest, &private_key),
         }
+    }
+
+    /// Sign a secp256k1 digest returning [r(32), s(32), v(1)] where v ∈ {27, 28}.
+    pub fn sign_eth_digest(digest: &[u8], private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let private_key = Zeroizing::new(private_key.to_vec());
+        secp256k1::sign_eth_digest(digest, &private_key)
     }
 
     /// Sign a digest with Ed25519 and return both the signature and public key bytes.
@@ -45,8 +55,7 @@ impl Signer {
 
     pub fn sign_eip712(typed_data_json: &str, private_key: &[u8]) -> Result<String, SignerError> {
         let digest = eip712::hash_typed_data(typed_data_json)?;
-        let private_key_vec = Zeroizing::new(private_key.to_vec());
-        let signature = Self::sign_digest(SignatureScheme::Secp256k1, digest.to_vec(), private_key_vec.to_vec())?;
+        let signature = Self::sign_eth_digest(&digest, private_key)?;
         Ok(hex::encode(signature))
     }
 }
@@ -54,6 +63,7 @@ impl Signer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testkit::TEST_PRIVATE_KEY;
 
     #[test]
     fn ed25519_sign_with_public_key_rejects_invalid_length() {
@@ -63,7 +73,7 @@ mod tests {
 
     #[test]
     fn ed25519_sign_with_public_key_returns_correct_lengths() {
-        let private_key = hex::decode("1e9d38b5274152a78dff1a86fa464ceadc1f4238ca2c17060c3c507349424a34").unwrap();
+        let private_key = hex::decode(TEST_PRIVATE_KEY).unwrap();
         let digest = b"test message";
 
         let (signature, public_key) = Signer::sign_ed25519_with_public_key(digest, &private_key).unwrap();

--- a/crates/signer/src/secp256k1.rs
+++ b/crates/signer/src/secp256k1.rs
@@ -1,17 +1,29 @@
 use k256::ecdsa::SigningKey as SecpSigningKey;
 use primitives::SignerError;
 
+pub const SIGNATURE_LENGTH: usize = 65;
+pub const RECOVERY_ID_INDEX: usize = SIGNATURE_LENGTH - 1;
 const ETHEREUM_RECOVERY_ID_OFFSET: u8 = 27;
 
-pub(crate) fn sign_digest(digest: &[u8], private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+/// Returns (signature_bytes, recovery_id) where recovery_id ∈ {0, 1}.
+pub(crate) fn sign_digest(digest: &[u8], private_key: &[u8]) -> Result<(Vec<u8>, u8), SignerError> {
     let signing_key = SecpSigningKey::from_slice(private_key).map_err(|_| SignerError::signing_error("Invalid Secp256k1 private key"))?;
     let (signature, recovery_id) = signing_key
         .sign_prehash_recoverable(digest)
         .map_err(|_| SignerError::signing_error("Failed to sign Secp256k1 digest"))?;
+    Ok((signature.to_bytes().to_vec(), u8::from(recovery_id)))
+}
 
-    let mut out = signature.to_bytes().to_vec();
-    out.push(u8::from(recovery_id) + ETHEREUM_RECOVERY_ID_OFFSET);
-    Ok(out)
+/// Returns [r(32), s(32), v(1)] where v ∈ {0, 1}.
+pub(crate) fn sign_digest_append_recovery(digest: &[u8], private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+    let (rs, v) = sign_digest(digest, private_key)?;
+    Ok([rs, vec![v]].concat())
+}
+
+/// Returns [r(32), s(32), v(1)] where v ∈ {27, 28} (Ethereum/Tron).
+pub(crate) fn sign_eth_digest(digest: &[u8], private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+    let (rs, v) = sign_digest(digest, private_key)?;
+    Ok([rs, vec![v + ETHEREUM_RECOVERY_ID_OFFSET]].concat())
 }
 
 pub fn public_key_from_private(private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
@@ -19,29 +31,63 @@ pub fn public_key_from_private(private_key: &[u8]) -> Result<Vec<u8>, SignerErro
     Ok(signing_key.verifying_key().to_sec1_bytes().to_vec())
 }
 
+/// Apply Ethereum recovery id offset (+27) to a 65-byte signature. Idempotent.
+pub fn apply_eth_recovery_id(signature: &mut [u8]) {
+    if signature.len() != 65 {
+        return;
+    }
+    let v = &mut signature[64];
+    if *v < ETHEREUM_RECOVERY_ID_OFFSET {
+        *v += ETHEREUM_RECOVERY_ID_OFFSET;
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ETHEREUM_RECOVERY_ID_OFFSET, SecpSigningKey, sign_digest};
+    use super::{ETHEREUM_RECOVERY_ID_OFFSET, SecpSigningKey, apply_eth_recovery_id, sign_digest, sign_eth_digest};
+    use crate::testkit::TEST_PRIVATE_KEY;
     use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+    const DIGEST: [u8; 32] = [7u8; 32];
 
     #[test]
-    fn sign_digest_uses_ethereum_recovery_id_values() {
-        let digest = [7u8; 32];
-        let private_key = hex::decode("1e9d38b5274152a78dff1a86fa464ceadc1f4238ca2c17060c3c507349424a34").unwrap();
-        let signature = sign_digest(&digest, &private_key).unwrap();
+    fn sign_digest_returns_raw_recovery_id() {
+        let private_key = hex::decode(TEST_PRIVATE_KEY).unwrap();
+        let (rs, v) = sign_digest(&DIGEST, &private_key).unwrap();
         let signing_key = SecpSigningKey::from_slice(&private_key).unwrap();
 
-        assert_eq!(signature.len(), 65);
+        assert_eq!(rs.len(), 64);
+        assert!(matches!(v, 0 | 1), "raw recovery id must be 0 or 1, got {v}");
 
-        match signature[64] {
-            27 | 28 => (),
-            value => panic!("unexpected recovery id: {value}"),
-        }
-
-        let recovery_id = RecoveryId::from_byte(signature[64] - ETHEREUM_RECOVERY_ID_OFFSET).unwrap();
-        let signature = Signature::try_from(&signature[..64]).unwrap();
-        let recovered = VerifyingKey::recover_from_prehash(&digest, &signature, recovery_id).unwrap();
-
+        let recovery_id = RecoveryId::from_byte(v).unwrap();
+        let signature = Signature::try_from(rs.as_slice()).unwrap();
+        let recovered = VerifyingKey::recover_from_prehash(&DIGEST, &signature, recovery_id).unwrap();
         assert_eq!(recovered.to_sec1_bytes().to_vec(), signing_key.verifying_key().to_sec1_bytes().to_vec());
+    }
+
+    #[test]
+    fn sign_eth_digest_applies_offset() {
+        let private_key = hex::decode(TEST_PRIVATE_KEY).unwrap();
+        let (rs, v) = sign_digest(&DIGEST, &private_key).unwrap();
+        let signature = sign_eth_digest(&DIGEST, &private_key).unwrap();
+
+        assert_eq!(rs, &signature[..64]);
+        assert_eq!(v + ETHEREUM_RECOVERY_ID_OFFSET, signature[64]);
+    }
+
+    #[test]
+    fn apply_recovery_id_offset() {
+        let mut sig = vec![0u8; 65];
+
+        sig[64] = 0;
+        apply_eth_recovery_id(&mut sig);
+        assert_eq!(sig[64], ETHEREUM_RECOVERY_ID_OFFSET);
+        apply_eth_recovery_id(&mut sig);
+        assert_eq!(sig[64], ETHEREUM_RECOVERY_ID_OFFSET);
+
+        sig[64] = 1;
+        apply_eth_recovery_id(&mut sig);
+        assert_eq!(sig[64], 1 + ETHEREUM_RECOVERY_ID_OFFSET);
+        apply_eth_recovery_id(&mut sig);
+        assert_eq!(sig[64], 1 + ETHEREUM_RECOVERY_ID_OFFSET);
     }
 }

--- a/gemstone/src/message/signer.rs
+++ b/gemstone/src/message/signer.rs
@@ -3,12 +3,12 @@ use std::borrow::Cow;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use bs58;
-use gem_evm::{ETHEREUM_RECOVERY_ID_OFFSET, RECOVERY_ID_INDEX, SIGNATURE_LENGTH, message::eip191_hash_message};
+use gem_evm::message::eip191_hash_message;
 use gem_sui::signer as sui_signer;
 use gem_ton::address::base64_to_hex_address;
 use gem_ton::signer::{TonSignDataResponse, TonSignMessageData, TonSignResult, sign_personal as ton_sign_personal};
 use primitives::hex::encode_with_0x;
-use signer::{SignatureScheme, Signer, hash_eip712};
+use signer::{SIGNATURE_LENGTH, SignatureScheme, Signer, apply_eth_recovery_id, hash_eip712};
 use std::time::{SystemTime, UNIX_EPOCH};
 use sui_types::PersonalMessage;
 
@@ -163,9 +163,7 @@ impl MessageSigner {
                     return encode_with_0x(data);
                 }
                 let mut signature = data.to_vec();
-                if signature[RECOVERY_ID_INDEX] < ETHEREUM_RECOVERY_ID_OFFSET {
-                    signature[RECOVERY_ID_INDEX] += ETHEREUM_RECOVERY_ID_OFFSET;
-                }
+                apply_eth_recovery_id(&mut signature);
                 encode_with_0x(&signature)
             }
             SignDigestType::SuiPersonal | SignDigestType::TonPersonal => BASE64.encode(data),
@@ -185,8 +183,8 @@ impl MessageSigner {
                 self.get_ton_result(&result)
             }
             SignDigestType::Eip191 | SignDigestType::Eip712 | SignDigestType::Siwe | SignDigestType::TronPersonal => {
-                let signed = Signer::sign_digest(SignatureScheme::Secp256k1, hash, private_key.to_vec())?;
-                Ok(self.get_result(&signed))
+                let signature = Signer::sign_eth_digest(&hash, &private_key)?;
+                Ok(encode_with_0x(&signature))
             }
             SignDigestType::Base58 => {
                 let signed = Signer::sign_digest(SignatureScheme::Ed25519, hash, private_key.to_vec())?;
@@ -325,16 +323,16 @@ Issued At: 2026-03-09T15:48:34.458Z"#;
             data: b"test".to_vec(),
         });
 
-        // Test recovery ID 0 -> 27 (0x1b)
+        // Raw recovery ID 0 -> 27 (0x1b)
         let mut sig = vec![0u8; 65];
         sig[64] = 0;
         assert!(decoder.get_result(&sig).ends_with("1b"));
 
-        // Test recovery ID 1 -> 28 (0x1c)
+        // Raw recovery ID 1 -> 28 (0x1c)
         sig[64] = 1;
         assert!(decoder.get_result(&sig).ends_with("1c"));
 
-        // Test already converted IDs stay unchanged
+        // Already converted IDs stay unchanged
         sig[64] = 27;
         assert!(decoder.get_result(&sig).ends_with("1b"));
 


### PR DESCRIPTION
The Ethereum recovery id offset (27) was hardcoded in the shared secp256k1 sign_digest, producing invalid signatures for non-Ethereum chains (e.g. Bitcoin BIP-137 headers became 66/67 instead of 39/40).

Split into chain-agnostic and Ethereum-specific signing:
- sign_digest returns raw recovery id (0/1)
- sign_eth_digest returns Ethereum-style v (27/28)
- apply_eth_recovery_id for the WalletConnect path (idempotent)

Add Signer::sign_eth_digest and use it in EIP-712, Tron, and message signers. Add BIP-137 header assertion to Bitcoin signer test.