### PR TITLE
Replace tiny-keccak with sha3::Keccak256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3239,9 +3239,9 @@ dependencies = [
 name = "gem_hash"
 version = "1.0.0"
 dependencies = [
+ "hex",
  "sha2 0.11.0",
  "sha3",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -4008,7 +4008,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5632,7 +5632,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5670,7 +5670,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,6 @@ zeroize = { version = "1.8.2" }
 ring = { version = "0.17.14", features = ["std"] }
 rand = { version = "0.10.0" }
 strum = { version = "0.28.0", features = ["derive"] }
-tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 curve25519-dalek = { version = "4.1.3" }
 ed25519-dalek = { version = "2", features = ["std"] }
 borsh = { version = "1.6.0", features = ["derive"] }

--- a/crates/gem_hash/Cargo.toml
+++ b/crates/gem_hash/Cargo.toml
@@ -4,6 +4,6 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+hex = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
-tiny-keccak = { workspace = true }

--- a/crates/gem_hash/src/keccak.rs
+++ b/crates/gem_hash/src/keccak.rs
@@ -1,10 +1,22 @@
-use tiny_keccak::{Hasher, Keccak};
+use sha3::{Digest, Keccak256};
 
 pub fn keccak256(bytes: &[u8]) -> [u8; 32] {
-    let mut hasher = Keccak::v256();
-    hasher.update(bytes);
+    Keccak256::digest(bytes).into()
+}
 
-    let mut hash = [0u8; 32];
-    hasher.finalize(&mut hash);
-    hash
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keccak256() {
+        assert_eq!(
+            hex::encode(keccak256(b"hello")),
+            "1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"
+        );
+        assert_eq!(
+            hex::encode(keccak256(b"")),
+            "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Remove `tiny-keccak` direct dependency, use `sha3::Keccak256` which was already a dependency
- Add `hex` to `gem_hash`
- Add `keccak256` unit test

## Test plan
- [x] `cargo clippy -p gem_hash -- -D warnings` passes
- [x] `just test gem_hash` passes