### PR TITLE
Add price suggestion utilities and bindings

### DIFF
--- a/crates/number_formatter/src/lib.rs
+++ b/crates/number_formatter/src/lib.rs
@@ -3,5 +3,6 @@ pub use big_number_formatter::{BigNumberFormatter, NumberFormatterError};
 pub mod currency;
 pub mod number_formatter;
 pub use number_formatter::NumberFormatter;
+pub mod price_suggestion;
 pub mod value_formatter;
 pub use value_formatter::{ValueFormatter, ValueStyle};

--- a/crates/number_formatter/src/price_suggestion.rs
+++ b/crates/number_formatter/src/price_suggestion.rs
@@ -1,0 +1,64 @@
+pub fn percentage_suggestions(price: f64) -> Vec<i32> {
+    let base = match price {
+        p if p < 100.0 => 5,
+        p if p < 10_000.0 => 3,
+        _ => 2,
+    };
+    vec![base, base * 2, base * 3]
+}
+
+pub fn price_rounded_values(price: f64, by_percent: f64) -> Vec<f64> {
+    if price < 0.01 || by_percent <= 0.0 {
+        return vec![];
+    }
+
+    let lower_target = price * (1.0 - by_percent / 100.0);
+    let upper_target = price * (1.0 + by_percent / 100.0);
+    let step = price_step(lower_target);
+
+    let lower = (lower_target / step).floor() * step;
+    let upper = if step > 1.0 {
+        (upper_target / step).round() * step
+    } else {
+        (upper_target / step).ceil() * step
+    };
+
+    vec![lower, upper]
+}
+
+fn price_step(value: f64) -> f64 {
+    match value {
+        v if v < 1.0 => 0.01,
+        v if v < 100.0 => 1.0,
+        v if v < 500.0 => 10.0,
+        v if v < 10_000.0 => 50.0,
+        _ => 1000.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_rounded(price: f64, by_percent: f64, expected: [f64; 2]) {
+        let result = price_rounded_values(price, by_percent);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_percentage_suggestions() {
+        assert_eq!(percentage_suggestions(50.0), vec![5, 10, 15]);
+        assert_eq!(percentage_suggestions(500.0), vec![3, 6, 9]);
+        assert_eq!(percentage_suggestions(10_000.0), vec![2, 4, 6]);
+    }
+
+    #[test]
+    fn test_price_rounded_values() {
+        assert_rounded(0.2829, 5.0, [0.26, 0.30]);
+        assert_rounded(767.55, 5.0, [700.0, 800.0]);
+        assert_rounded(95_432.0, 5.0, [90_000.0, 100_000.0]);
+
+        assert!(price_rounded_values(0.0, 5.0).is_empty());
+        assert!(price_rounded_values(100.0, -5.0).is_empty());
+    }
+}

--- a/gemstone/src/lib.rs
+++ b/gemstone/src/lib.rs
@@ -12,6 +12,7 @@ pub mod models;
 pub mod network;
 pub mod payment;
 pub mod perpetual;
+pub mod price_alert_formatter;
 pub mod signer;
 pub mod siwe;
 pub mod wallet_connect;

--- a/gemstone/src/price_alert_formatter.rs
+++ b/gemstone/src/price_alert_formatter.rs
@@ -1,11 +1,20 @@
 use number_formatter::price_suggestion;
 
-#[uniffi::export]
-pub fn price_alert_percentage_suggestions(price: f64) -> Vec<i32> {
-    price_suggestion::percentage_suggestions(price)
-}
+#[derive(Default, uniffi::Object)]
+pub struct PriceAlertFormatter {}
 
 #[uniffi::export]
-pub fn price_alert_rounded_values(price: f64, by_percent: f64) -> Vec<f64> {
-    price_suggestion::price_rounded_values(price, by_percent)
+impl PriceAlertFormatter {
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn percentage_suggestions(&self, price: f64) -> Vec<i32> {
+        price_suggestion::percentage_suggestions(price)
+    }
+
+    pub fn rounded_values(&self, price: f64, by_percent: f64) -> Vec<f64> {
+        price_suggestion::price_rounded_values(price, by_percent)
+    }
 }

--- a/gemstone/src/price_alert_formatter.rs
+++ b/gemstone/src/price_alert_formatter.rs
@@ -1,0 +1,11 @@
+use number_formatter::price_suggestion;
+
+#[uniffi::export]
+pub fn price_alert_percentage_suggestions(price: f64) -> Vec<i32> {
+    price_suggestion::percentage_suggestions(price)
+}
+
+#[uniffi::export]
+pub fn price_alert_rounded_values(price: f64, by_percent: f64) -> Vec<f64> {
+    price_suggestion::price_rounded_values(price, by_percent)
+}


### PR DESCRIPTION
Introduce a new price_suggestion module in crates/number_formatter with helpers to compute percentage_suggestions and rounded price targets (price_rounded_values) plus unit tests and an internal price_step helper. Export the module from number_formatter::lib. Add a new gemstone::price_alert_formatter that exposes uniffi bindings (price_alert_percentage_suggestions, price_alert_rounded_values) which delegate to the number_formatter helpers, and register the module in gemstone::lib. These changes provide reusable logic for alert percentage suggestions and rounded price targets for FFI consumers, including edge-case handling for tiny or invalid inputs.