### PR TITLE
Add Tonstakers earn provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9222,9 +9222,11 @@ dependencies = [
  "gem_client",
  "gem_evm",
  "gem_jsonrpc",
+ "gem_ton",
  "num-bigint",
  "primitives",
- "reqwest 0.13.2",
+ "settings",
+ "swapper",
  "tokio",
 ]
 

--- a/crates/gem_ton/src/lib.rs
+++ b/crates/gem_ton/src/lib.rs
@@ -13,6 +13,7 @@ pub mod tvm;
 pub mod address;
 pub mod constants;
 pub mod models;
+pub mod tonstakers;
 
 pub use address::{Address, validate_address};
 pub use primitives::AddressError;

--- a/crates/gem_ton/src/models/rpc.rs
+++ b/crates/gem_ton/src/models/rpc.rs
@@ -1,7 +1,52 @@
+use std::error::Error;
+
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
+use serde_serializers::biguint_from_hex_str;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiResult<T> {
     pub ok: bool,
     pub result: T,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RunGetMethodResult {
+    pub stack: Vec<RunGetMethodStackItem>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum RunGetMethodStackItem {
+    Num {
+        value: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
+impl RunGetMethodResult {
+    pub fn get_num(&self, index: usize) -> Result<BigUint, Box<dyn Error + Send + Sync>> {
+        match self.stack.get(index) {
+            Some(RunGetMethodStackItem::Num { value }) => biguint_from_hex_str(value),
+            _ => Err(format!("expected num at TON stack index {index}").into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_get_num() {
+        let value = json!({ "stack": [{ "type": "num", "value": "0xff" }, { "type": "cell", "value": "..." }] });
+        let result: RunGetMethodResult = serde_json::from_value(value).unwrap();
+
+        assert_eq!(result.get_num(0).unwrap(), BigUint::from(255u32));
+        assert!(result.get_num(1).is_err());
+        assert!(result.get_num(2).is_err());
+    }
 }

--- a/crates/gem_ton/src/rpc/client.rs
+++ b/crates/gem_ton/src/rpc/client.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 
 use primitives::{Asset, AssetId, AssetType, chain::Chain};
-use serde_json;
 
 use chain_traits::{ChainAccount, ChainAddressStatus, ChainPerpetual, ChainStaking, ChainTraits};
 use gem_client::{Client, ClientExt};

--- a/crates/gem_ton/src/signer/chain_signer.rs
+++ b/crates/gem_ton/src/signer/chain_signer.rs
@@ -28,4 +28,8 @@ impl ChainSigner for TonChainSigner {
     fn sign_swap(&self, input: &SignerInput, private_key: &[u8]) -> Result<Vec<String>, SignerError> {
         TonSigner::new(private_key)?.sign_swap(input, None)
     }
+
+    fn sign_earn(&self, input: &SignerInput, private_key: &[u8]) -> Result<Vec<String>, SignerError> {
+        TonSigner::new(private_key)?.sign_earn(input, None)
+    }
 }

--- a/crates/gem_ton/src/signer/transaction/earn.rs
+++ b/crates/gem_ton/src/signer/transaction/earn.rs
@@ -5,9 +5,6 @@ use crate::{tonstakers, tvm::BagOfCells};
 
 pub(super) fn build_request(input: &SignerInput) -> Result<TransferRequest, SignerError> {
     let earn_data = input.input_type.get_earn_data()?;
-    if earn_data.call_data.is_empty() {
-        return Err(SignerError::invalid_input("earn call data is required"));
-    }
     let payload = BagOfCells::parse_base64_root(&earn_data.call_data)?;
     let earn_type = input.input_type.get_earn_type()?;
     let attached_value = tonstakers::attached_value(earn_type, &input.value)?;

--- a/crates/gem_ton/src/signer/transaction/earn.rs
+++ b/crates/gem_ton/src/signer/transaction/earn.rs
@@ -1,0 +1,15 @@
+use primitives::{SignerError, SignerInput};
+
+use super::request::TransferRequest;
+use crate::{tonstakers, tvm::BagOfCells};
+
+pub(super) fn build_request(input: &SignerInput) -> Result<TransferRequest, SignerError> {
+    let earn_data = input.input_type.get_earn_data()?;
+    if earn_data.call_data.is_empty() {
+        return Err(SignerError::invalid_input("earn call data is required"));
+    }
+    let payload = BagOfCells::parse_base64_root(&earn_data.call_data)?;
+    let earn_type = input.input_type.get_earn_type()?;
+    let attached_value = tonstakers::attached_value(earn_type, &input.value)?;
+    TransferRequest::new_with_payload(&earn_data.contract_address, &attached_value.to_string(), input.memo.clone(), Some(payload), true, None)
+}

--- a/crates/gem_ton/src/signer/transaction/mod.rs
+++ b/crates/gem_ton/src/signer/transaction/mod.rs
@@ -1,3 +1,4 @@
+mod earn;
 pub(super) mod message;
 pub(super) mod request;
 mod sign;

--- a/crates/gem_ton/src/signer/transaction/sign.rs
+++ b/crates/gem_ton/src/signer/transaction/sign.rs
@@ -5,6 +5,7 @@ use num_bigint::BigUint;
 use primitives::{FeeOption, SignerError, SignerInput};
 
 use super::{
+    earn,
     message::{InternalMessage, build_internal_message},
     request::{JettonTransferRequest, TransferRequest},
 };
@@ -52,6 +53,11 @@ impl TonSigner {
             true,
             None,
         )?;
+        Ok(vec![self.sign_requests(vec![request], input.metadata.get_sequence()?, expire_at)?])
+    }
+
+    pub fn sign_earn(&self, input: &SignerInput, expire_at: Option<u32>) -> Result<Vec<String>, SignerError> {
+        let request = earn::build_request(input)?;
         Ok(vec![self.sign_requests(vec![request], input.metadata.get_sequence()?, expire_at)?])
     }
 

--- a/crates/gem_ton/src/tonstakers/mod.rs
+++ b/crates/gem_ton/src/tonstakers/mod.rs
@@ -1,0 +1,17 @@
+pub const STAKING_CONTRACT: &str = "EQCkWxfyhAkim3g2DjKQQg8T5P4g-Q1-K_jErGcDJZ4i-vqR";
+pub const TS_TON_MASTER: &str = "0:BDF3FA8098D129B54B4F73B5BAC5D1E1FD91EB054169C3916DFC8CCD536D1000";
+
+#[cfg(feature = "rpc")]
+mod pool;
+
+#[cfg(feature = "rpc")]
+pub use pool::{PoolFullData, get_pool_full_data};
+
+#[cfg(feature = "signer")]
+mod payload;
+
+#[cfg(feature = "signer")]
+pub use payload::{build_stake_payload_base64, build_unstake_payload_base64};
+
+#[cfg(feature = "signer")]
+pub(crate) use payload::attached_value;

--- a/crates/gem_ton/src/tonstakers/payload.rs
+++ b/crates/gem_ton/src/tonstakers/payload.rs
@@ -1,0 +1,97 @@
+use std::str::FromStr;
+
+use num_bigint::BigUint;
+use primitives::{EarnType, SignerError};
+
+use crate::{
+    Address,
+    tvm::{BagOfCells, CellBuilder},
+};
+
+// Placeholder id "GEM" + tagged timestamp; replace once Tonstakers issues an official partner_id.
+const PARTNER_CODE: u64 = 0x47454D0069EEF127;
+const STAKE_OPCODE: u32 = 0x47D54391;
+const STAKE_FEE: u64 = 1_000_000_000;
+const UNSTAKE_OPCODE: u32 = 0x595F07BC;
+const UNSTAKE_FEE: u64 = 1_050_000_000;
+
+pub(crate) fn attached_value(earn_type: &EarnType, value: &str) -> Result<BigUint, SignerError> {
+    match earn_type {
+        EarnType::Deposit(_) => Ok(BigUint::from_str(value)? + BigUint::from(STAKE_FEE)),
+        EarnType::Withdraw(_) => Ok(BigUint::from(UNSTAKE_FEE)),
+    }
+}
+
+pub fn build_stake_payload_base64() -> Result<String, SignerError> {
+    let mut builder = CellBuilder::new();
+    builder.store_u32(32, STAKE_OPCODE)?.store_u64(64, 1)?.store_u64(64, PARTNER_CODE)?;
+    Ok(BagOfCells::from_root(builder.build()?).to_base64(true)?)
+}
+
+pub fn build_unstake_payload_base64(owner: &Address, amount: &BigUint) -> Result<String, SignerError> {
+    // Tonstakers unstake flags cell: wait_till_round_end=0, fill_or_kill=0.
+    let mut flags = CellBuilder::new();
+    flags.store_u8(2, 0)?;
+
+    let mut builder = CellBuilder::new();
+    builder
+        .store_u32(32, UNSTAKE_OPCODE)?
+        .store_u64(64, 0)?
+        .store_coins(amount)?
+        .store_address(owner)?
+        .store_bit(true)?
+        .store_child(flags.build()?)?;
+    Ok(BagOfCells::from_root(builder.build()?).to_base64(true)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use num_bigint::BigUint;
+    use primitives::{Asset, Chain, ContractCallData, EarnType, SignerInput, TransactionInputType, TransactionLoadMetadata, YieldProvider};
+
+    use super::{build_stake_payload_base64, build_unstake_payload_base64};
+    use crate::{Address, signer::TonSigner};
+
+    const TEST_TON_PRIVATE_KEY: &str = "c7702dadcd00d470df27dee0ddd97fbcf9deba52b60f7dd2b296ff42bb1fcad6";
+    const SENDER_TOKEN_ADDRESS: &str = "EQAlgB03OjJKdXrlwZiGJD5snSzPKF2VL5bErJn_cqJANGH9";
+
+    fn test_signer() -> TonSigner {
+        let private_key = hex::decode(TEST_TON_PRIVATE_KEY).unwrap();
+        TonSigner::new(&private_key).unwrap()
+    }
+
+    fn signer_input(earn_type: EarnType, call_data: String, value: &str) -> SignerInput {
+        let input_type = TransactionInputType::Earn(Asset::from_chain(Chain::Ton), earn_type, ContractCallData::new(SENDER_TOKEN_ADDRESS.to_string(), call_data));
+        SignerInput::mock_with_input_type(input_type, "", "", value, TransactionLoadMetadata::mock_ton(1))
+    }
+
+    #[test]
+    fn test_build_stake_payload_base64() {
+        assert_eq!(build_stake_payload_base64().unwrap(), "te6cckEBAQEAFgAAKEfVQ5EAAAAAAAAAAUdFTQBp7vEnOxjgfw==");
+    }
+
+    #[test]
+    fn test_build_unstake_payload_base64() {
+        let owner = Address::parse("EQCOh0t62bvrv8SIELiTnJj1BYAkbxmYIEDbyyU8TD2veND8").unwrap();
+        assert_eq!(
+            build_unstake_payload_base64(&owner, &BigUint::from(5_000_000_000u64)).unwrap(),
+            "te6cckEBAgEAOQABZllfB7wAAAAAAAAAAFASoF8gCAEdDpb1s3fXf4kQIXEnOTHqCwBI3jMwQIG3lkp4mHte8QEAASDleV8G"
+        );
+    }
+
+    #[test]
+    fn test_sign_earn() {
+        let signer = test_signer();
+        let provider = YieldProvider::Tonstakers.delegation_validator(Chain::Ton);
+        let input = signer_input(EarnType::Deposit(provider), build_stake_payload_base64().unwrap(), "10000");
+
+        let signed = signer.sign_earn(&input, Some(1_000_000_000)).unwrap();
+
+        assert_eq!(
+            signed,
+            vec![
+                "te6cckEBBAEAxAABRYgBkF1w67cBLG0e0D7j0y2ShzflCe2JrlAjS4pC8UHg85AMAQGcyRclzA0Phkl4EMv6ba3GIp6Tx3f1PU9foE3I/W8msQmi8NMYR7h0v8L2OlXLMvqvJ+WWJMk/D/s+CyNQcpFQASmpoxc7msoAAAAAAQADAgFoYgASwA6bnRklOr1y4MxDEh82TpZnlC7Kl8tiVkz/uVEgGiHc14iAAAAAAAAAAAAAAAAAAQMAKEfVQ5EAAAAAAAAAAUdFTQBp7vEnTx0W9Q==".to_string()
+            ]
+        );
+    }
+}

--- a/crates/gem_ton/src/tonstakers/payload.rs
+++ b/crates/gem_ton/src/tonstakers/payload.rs
@@ -50,20 +50,12 @@ mod tests {
     use primitives::{Asset, Chain, ContractCallData, EarnType, SignerInput, TransactionInputType, TransactionLoadMetadata, YieldProvider};
 
     use super::{build_stake_payload_base64, build_unstake_payload_base64};
-    use crate::{Address, signer::TonSigner};
+    use crate::{
+        Address,
+        signer::{TonSigner, testkit::TEST_ADDRESS as TON_TEST_WALLET_ADDRESS},
+    };
 
     const TEST_TON_PRIVATE_KEY: &str = "c7702dadcd00d470df27dee0ddd97fbcf9deba52b60f7dd2b296ff42bb1fcad6";
-    const SENDER_TOKEN_ADDRESS: &str = "EQAlgB03OjJKdXrlwZiGJD5snSzPKF2VL5bErJn_cqJANGH9";
-
-    fn test_signer() -> TonSigner {
-        let private_key = hex::decode(TEST_TON_PRIVATE_KEY).unwrap();
-        TonSigner::new(&private_key).unwrap()
-    }
-
-    fn signer_input(earn_type: EarnType, call_data: String, value: &str) -> SignerInput {
-        let input_type = TransactionInputType::Earn(Asset::from_chain(Chain::Ton), earn_type, ContractCallData::new(SENDER_TOKEN_ADDRESS.to_string(), call_data));
-        SignerInput::mock_with_input_type(input_type, "", "", value, TransactionLoadMetadata::mock_ton(1))
-    }
 
     #[test]
     fn test_build_stake_payload_base64() {
@@ -72,25 +64,31 @@ mod tests {
 
     #[test]
     fn test_build_unstake_payload_base64() {
-        let owner = Address::parse("EQCOh0t62bvrv8SIELiTnJj1BYAkbxmYIEDbyyU8TD2veND8").unwrap();
+        let owner = Address::parse(TON_TEST_WALLET_ADDRESS).unwrap();
         assert_eq!(
             build_unstake_payload_base64(&owner, &BigUint::from(5_000_000_000u64)).unwrap(),
-            "te6cckEBAgEAOQABZllfB7wAAAAAAAAAAFASoF8gCAEdDpb1s3fXf4kQIXEnOTHqCwBI3jMwQIG3lkp4mHte8QEAASDleV8G"
+            "te6cckEBAgEAOQABZllfB7wAAAAAAAAAAFASoF8gCACxq4qfdwkRXv1VoZuOs5Ue3+8/kqqiDYJnNgb9gUgGjwEAASDYnkB8"
         );
     }
 
     #[test]
     fn test_sign_earn() {
-        let signer = test_signer();
+        let private_key = hex::decode(TEST_TON_PRIVATE_KEY).unwrap();
+        let signer = TonSigner::new(&private_key).unwrap();
         let provider = YieldProvider::Tonstakers.delegation_validator(Chain::Ton);
-        let input = signer_input(EarnType::Deposit(provider), build_stake_payload_base64().unwrap(), "10000");
+        let input_type = TransactionInputType::Earn(
+            Asset::from_chain(Chain::Ton),
+            EarnType::Deposit(provider),
+            ContractCallData::new(TON_TEST_WALLET_ADDRESS.to_string(), build_stake_payload_base64().unwrap()),
+        );
+        let input = SignerInput::mock_with_input_type(input_type, "", "", "10000", TransactionLoadMetadata::mock_ton(1));
 
         let signed = signer.sign_earn(&input, Some(1_000_000_000)).unwrap();
 
         assert_eq!(
             signed,
             vec![
-                "te6cckEBBAEAxAABRYgBkF1w67cBLG0e0D7j0y2ShzflCe2JrlAjS4pC8UHg85AMAQGcyRclzA0Phkl4EMv6ba3GIp6Tx3f1PU9foE3I/W8msQmi8NMYR7h0v8L2OlXLMvqvJ+WWJMk/D/s+CyNQcpFQASmpoxc7msoAAAAAAQADAgFoYgASwA6bnRklOr1y4MxDEh82TpZnlC7Kl8tiVkz/uVEgGiHc14iAAAAAAAAAAAAAAAAAAQMAKEfVQ5EAAAAAAAAAAUdFTQBp7vEnTx0W9Q==".to_string()
+                "te6cckEBBAEAxAABRYgBkF1w67cBLG0e0D7j0y2ShzflCe2JrlAjS4pC8UHg85AMAQGc586+/tdveRSv7FpL3QNz4uEs7fsaNih6wD1u9UeqSjlwvKknRCpL4kxqMzR67FdLNQ3eeriBeKX7dJEgRPopDimpoxc7msoAAAAAAQADAgFoYgAsauKn3cJEV79VaGbjrOVHt/vP5Kqog2CZzYG/YFIBo6Hc14iAAAAAAAAAAAAAAAAAAQMAKEfVQ5EAAAAAAAAAAUdFTQBp7vEn4cjcXg==".to_string()
             ]
         );
     }

--- a/crates/gem_ton/src/tonstakers/payload.rs
+++ b/crates/gem_ton/src/tonstakers/payload.rs
@@ -8,8 +8,7 @@ use crate::{
     tvm::{BagOfCells, CellBuilder},
 };
 
-// Placeholder id "GEM" + tagged timestamp; replace once Tonstakers issues an official partner_id.
-const PARTNER_CODE: u64 = 0x47454D0069EEF127;
+const PARTNER_CODE: u64 = 0x000000106765cd3b;
 const STAKE_OPCODE: u32 = 0x47D54391;
 const STAKE_FEE: u64 = 1_000_000_000;
 const UNSTAKE_OPCODE: u32 = 0x595F07BC;
@@ -59,7 +58,7 @@ mod tests {
 
     #[test]
     fn test_build_stake_payload_base64() {
-        assert_eq!(build_stake_payload_base64().unwrap(), "te6cckEBAQEAFgAAKEfVQ5EAAAAAAAAAAUdFTQBp7vEnOxjgfw==");
+        assert_eq!(build_stake_payload_base64().unwrap(), "te6cckEBAQEAFgAAKEfVQ5EAAAAAAAAAAQAAABBnZc07HgacMQ==");
     }
 
     #[test]
@@ -88,7 +87,7 @@ mod tests {
         assert_eq!(
             signed,
             vec![
-                "te6cckEBBAEAxAABRYgBkF1w67cBLG0e0D7j0y2ShzflCe2JrlAjS4pC8UHg85AMAQGc586+/tdveRSv7FpL3QNz4uEs7fsaNih6wD1u9UeqSjlwvKknRCpL4kxqMzR67FdLNQ3eeriBeKX7dJEgRPopDimpoxc7msoAAAAAAQADAgFoYgAsauKn3cJEV79VaGbjrOVHt/vP5Kqog2CZzYG/YFIBo6Hc14iAAAAAAAAAAAAAAAAAAQMAKEfVQ5EAAAAAAAAAAUdFTQBp7vEn4cjcXg==".to_string()
+                "te6cckEBBAEAxAABRYgBkF1w67cBLG0e0D7j0y2ShzflCe2JrlAjS4pC8UHg85AMAQGc7lIsHiR1BaRlPmDkfMkHAvxvlbsJ1391Wonok5rMuLPKeH40GeEHqwp0XOlcRUdPx+rZqgah1TLhJ3662SfeDimpoxc7msoAAAAAAQADAgFoYgAsauKn3cJEV79VaGbjrOVHt/vP5Kqog2CZzYG/YFIBo6Hc14iAAAAAAAAAAAAAAAAAAQMAKEfVQ5EAAAAAAAAAAQAAABBnZc07mOCPIw==".to_string()
             ]
         );
     }

--- a/crates/gem_ton/src/tonstakers/pool.rs
+++ b/crates/gem_ton/src/tonstakers/pool.rs
@@ -1,0 +1,72 @@
+use std::error::Error;
+
+use num_bigint::BigUint;
+
+use gem_client::{Client, ClientExt};
+
+use crate::models::RunGetMethodResult;
+use crate::rpc::client::TonClient;
+
+// Stack offsets in the Tonstakers pool `get_pool_full_data` get-method tuple.
+// Layout source: ton-blockchain/liquid-staking-contract `compose_pool_full_data_internal`.
+const POOL_FULL_DATA_TOTAL_BALANCE_INDEX: usize = 2;
+const POOL_FULL_DATA_SUPPLY_INDEX: usize = 13;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PoolFullData {
+    pub total_balance: BigUint,
+    pub supply: BigUint,
+}
+
+impl PoolFullData {
+    pub fn from_stack(result: &RunGetMethodResult) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        Ok(Self {
+            total_balance: result.get_num(POOL_FULL_DATA_TOTAL_BALANCE_INDEX)?,
+            supply: result.get_num(POOL_FULL_DATA_SUPPLY_INDEX)?,
+        })
+    }
+}
+
+pub async fn get_pool_full_data<C: Client>(client: &TonClient<C>, address: &str) -> Result<PoolFullData, Box<dyn Error + Send + Sync>> {
+    let result: RunGetMethodResult = client
+        .client
+        .post(
+            "/api/v3/runGetMethod",
+            &serde_json::json!({
+                "address": address,
+                "method": "get_pool_full_data",
+                "stack": [],
+            }),
+        )
+        .await?;
+    PoolFullData::from_stack(&result)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::*;
+
+    const MAX_LOAN_PER_VALIDATOR_INDEX: usize = 10;
+
+    fn num_stack_item(value: i64) -> Value {
+        let hex = if value < 0 { format!("-0x{:x}", value.unsigned_abs()) } else { format!("0x{value:x}") };
+        json!({ "type": "num", "value": hex })
+    }
+
+    #[test]
+    fn test_pool_full_data_from_stack() {
+        let mut stack = vec![num_stack_item(0); POOL_FULL_DATA_SUPPLY_INDEX + 1];
+        stack[POOL_FULL_DATA_TOTAL_BALANCE_INDEX] = num_stack_item(55_036_943_253_694_618);
+        stack[MAX_LOAN_PER_VALIDATOR_INDEX] = num_stack_item(-1);
+        stack[POOL_FULL_DATA_SUPPLY_INDEX] = num_stack_item(50_324_580_070_537_824);
+
+        let value = json!({ "stack": stack });
+        let result: RunGetMethodResult = serde_json::from_value(value).unwrap();
+        let data = PoolFullData::from_stack(&result).unwrap();
+
+        assert_eq!(data.total_balance, BigUint::from(55_036_943_253_694_618_u64));
+        assert_eq!(data.supply, BigUint::from(50_324_580_070_537_824_u64));
+    }
+}

--- a/crates/primitives/src/contract_call_data.rs
+++ b/crates/primitives/src/contract_call_data.rs
@@ -11,3 +11,14 @@ pub struct ContractCallData {
     pub approval: Option<ApprovalData>,
     pub gas_limit: Option<String>,
 }
+
+impl ContractCallData {
+    pub fn new(contract_address: String, call_data: String) -> Self {
+        Self {
+            contract_address,
+            call_data,
+            approval: None,
+            gas_limit: None,
+        }
+    }
+}

--- a/crates/primitives/src/transaction_input_type.rs
+++ b/crates/primitives/src/transaction_input_type.rs
@@ -79,6 +79,13 @@ impl TransactionInputType {
         }
     }
 
+    pub fn get_earn_type(&self) -> Result<&EarnType, &'static str> {
+        match self {
+            TransactionInputType::Earn(_, earn_type, _) => Ok(earn_type),
+            _ => Err("expected earn transaction"),
+        }
+    }
+
     pub fn get_stake_type(&self) -> Result<&StakeType, &'static str> {
         match self {
             TransactionInputType::Stake(_, stake_type) => Ok(stake_type),

--- a/crates/primitives/src/yield_provider.rs
+++ b/crates/primitives/src/yield_provider.rs
@@ -2,18 +2,50 @@ use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display, EnumString};
 use typeshare::typeshare;
 
+use crate::{Chain, DelegationValidator, StakeProviderType};
+
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, Display, AsRefStr, EnumString, PartialEq, Eq)]
 #[typeshare(swift = "Equatable, CaseIterable, Sendable")]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum YieldProvider {
     Yo,
+    Tonstakers,
 }
 
 impl YieldProvider {
     pub fn name(&self) -> &str {
         match self {
             Self::Yo => "Yo",
+            Self::Tonstakers => "Tonstakers",
         }
+    }
+
+    pub fn delegation_validator(&self, chain: Chain) -> DelegationValidator {
+        DelegationValidator {
+            chain,
+            id: self.as_ref().to_string(),
+            name: self.name().to_string(),
+            is_active: true,
+            commission: 0.0,
+            apr: 0.0,
+            provider_type: StakeProviderType::Earn,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_delegation_validator() {
+        let result = YieldProvider::Yo.delegation_validator(Chain::Base);
+
+        assert_eq!(result.id, "yo");
+        assert_eq!(result.name, "Yo");
+        assert_eq!(result.chain, Chain::Base);
+        assert_eq!(result.apr, 0.0);
+        assert_eq!(result.provider_type, StakeProviderType::Earn);
     }
 }

--- a/crates/yielder/Cargo.toml
+++ b/crates/yielder/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 [features]
 default = []
 yield_integration_tests = [
-    "gem_jsonrpc/reqwest",
     "gem_client/reqwest",
+    "settings/testkit",
     "tokio/rt-multi-thread",
 ]
 
@@ -19,6 +19,7 @@ num-bigint = { workspace = true }
 gem_client = { path = "../gem_client" }
 gem_evm = { path = "../gem_evm", features = ["rpc"] }
 gem_jsonrpc = { path = "../gem_jsonrpc" }
+gem_ton = { path = "../gem_ton", features = ["rpc", "signer"] }
 primitives = { path = "../primitives" }
 async-trait = { workspace = true }
 futures = { workspace = true }
@@ -26,5 +27,6 @@ futures = { workspace = true }
 [dev-dependencies]
 gem_client = { path = "../gem_client", features = ["reqwest"] }
 gem_jsonrpc = { path = "../gem_jsonrpc", features = ["reqwest"] }
-reqwest = { workspace = true }
+settings = { path = "../settings", features = ["testkit"] }
+swapper = { path = "../swapper", features = ["reqwest_provider"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/yielder/src/client_factory.rs
+++ b/crates/yielder/src/client_factory.rs
@@ -1,13 +1,18 @@
 use gem_evm::rpc::EthereumClient;
-use gem_jsonrpc::alien::{self, RpcClient, RpcProvider};
+use gem_jsonrpc::alien::{RpcClient, RpcProvider};
 use gem_jsonrpc::client::JsonRpcClient;
 use primitives::{Chain, EVMChain};
 use std::sync::Arc;
 
 use crate::YielderError;
 
+pub fn create_chain_client(provider: Arc<dyn RpcProvider>, chain: Chain) -> Result<RpcClient, YielderError> {
+    let endpoint = provider.get_endpoint(chain).map_err(|_| YielderError::NotSupportedChain)?;
+    Ok(RpcClient::new(endpoint, provider))
+}
+
 pub fn create_client(provider: Arc<dyn RpcProvider>, chain: Chain) -> Result<JsonRpcClient<RpcClient>, YielderError> {
-    alien::create_client(provider, chain).map_err(|_| YielderError::NotSupportedChain)
+    Ok(JsonRpcClient::new(create_chain_client(provider, chain)?))
 }
 
 pub fn create_eth_client(provider: Arc<dyn RpcProvider>, chain: Chain) -> Result<EthereumClient<RpcClient>, YielderError> {

--- a/crates/yielder/src/error.rs
+++ b/crates/yielder/src/error.rs
@@ -3,10 +3,12 @@ use std::fmt::{self, Formatter};
 
 use alloy_primitives::hex::FromHexError;
 use alloy_primitives::ruint::ParseError;
+use primitives::SignerError;
 
 #[derive(Debug, Clone)]
 pub enum YielderError {
     NetworkError(String),
+    InvalidInput(String),
     NotSupportedChain,
     NotSupportedAsset,
 }
@@ -15,6 +17,7 @@ impl fmt::Display for YielderError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::NetworkError(msg) => write!(f, "{msg}"),
+            Self::InvalidInput(msg) => write!(f, "{msg}"),
             Self::NotSupportedChain => write!(f, "Not supported chain"),
             Self::NotSupportedAsset => write!(f, "Not supported asset"),
         }
@@ -23,15 +26,29 @@ impl fmt::Display for YielderError {
 
 impl Error for YielderError {}
 
+impl YielderError {
+    pub fn invalid_input(message: impl Into<String>) -> Self {
+        Self::InvalidInput(message.into())
+    }
+}
+
 impl From<FromHexError> for YielderError {
     fn from(err: FromHexError) -> Self {
-        Self::NetworkError(err.to_string())
+        Self::InvalidInput(err.to_string())
     }
 }
 
 impl From<ParseError> for YielderError {
     fn from(err: ParseError) -> Self {
-        Self::NetworkError(err.to_string())
+        Self::InvalidInput(err.to_string())
+    }
+}
+
+impl From<SignerError> for YielderError {
+    fn from(err: SignerError) -> Self {
+        match err {
+            SignerError::InvalidInput(message) | SignerError::SigningError(message) => Self::InvalidInput(message),
+        }
     }
 }
 

--- a/crates/yielder/src/lib.rs
+++ b/crates/yielder/src/lib.rs
@@ -1,6 +1,7 @@
 mod client_factory;
 mod error;
 mod provider;
+mod tonstakers;
 mod yielder;
 mod yo;
 

--- a/crates/yielder/src/lib.rs
+++ b/crates/yielder/src/lib.rs
@@ -5,6 +5,20 @@ mod tonstakers;
 mod yielder;
 mod yo;
 
+use std::{collections::HashMap, str::FromStr};
+
+use primitives::{AssetId, YieldProvider};
+
 pub use error::YielderError;
 pub use provider::EarnProvider;
 pub use yielder::Yielder;
+
+pub fn get_underlying_assets_by_provider(provider_id: &str) -> HashMap<AssetId, Vec<AssetId>> {
+    let Ok(provider) = YieldProvider::from_str(provider_id) else {
+        return HashMap::new();
+    };
+    match provider {
+        YieldProvider::Tonstakers => <tonstakers::TonstakersProvider as EarnProvider>::underlying_assets(),
+        YieldProvider::Yo => <yo::YoEarnProvider as EarnProvider>::underlying_assets(),
+    }
+}

--- a/crates/yielder/src/provider.rs
+++ b/crates/yielder/src/provider.rs
@@ -1,11 +1,15 @@
 use async_trait::async_trait;
 use primitives::{AssetBalance, AssetId, Chain, ContractCallData, DelegationBase, DelegationValidator, EarnType};
+use std::collections::HashMap;
 
 use crate::error::YielderError;
 
 #[async_trait]
 pub trait EarnProvider: Send + Sync {
     fn get_provider(&self, asset_id: &AssetId) -> Option<DelegationValidator>;
+    fn underlying_assets() -> HashMap<AssetId, Vec<AssetId>>
+    where
+        Self: Sized;
 
     async fn get_position(&self, address: &str, asset_id: &AssetId) -> Result<Option<DelegationBase>, YielderError>;
     async fn get_balance(&self, chain: Chain, address: &str, token_ids: &[String]) -> Result<Vec<AssetBalance>, YielderError>;

--- a/crates/yielder/src/tonstakers/mapper.rs
+++ b/crates/yielder/src/tonstakers/mapper.rs
@@ -1,0 +1,90 @@
+use num_bigint::BigUint;
+use primitives::{AssetId, Chain, DelegationBase, DelegationState, YieldProvider};
+
+pub fn map_to_delegation(balance: BigUint, shares: BigUint) -> DelegationBase {
+    let provider = YieldProvider::Tonstakers.delegation_validator(Chain::Ton);
+    let asset_id = AssetId::from_chain(Chain::Ton);
+
+    DelegationBase {
+        delegation_id: format!("{}-{}", provider.id, asset_id),
+        validator_id: provider.id,
+        asset_id,
+        state: DelegationState::Active,
+        balance,
+        shares,
+        rewards: BigUint::ZERO,
+        completion_date: None,
+    }
+}
+
+pub fn map_staked_balance(shares: &BigUint, total_balance: &BigUint, supply: &BigUint) -> BigUint {
+    if supply == &BigUint::ZERO {
+        return BigUint::ZERO;
+    }
+    (shares * total_balance) / supply
+}
+
+pub fn map_redeem_shares(amount: &BigUint, total_balance: &BigUint, supply: &BigUint, total_shares: &BigUint) -> BigUint {
+    if total_balance == &BigUint::ZERO {
+        return BigUint::ZERO;
+    }
+
+    let redeem_shares = (amount * supply) / total_balance;
+    if total_shares > &redeem_shares && total_shares - &redeem_shares <= BigUint::from(1u8) {
+        total_shares.clone()
+    } else {
+        redeem_shares.min(total_shares.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_staked_balance() {
+        assert_eq!(
+            map_staked_balance(&BigUint::from(1_000_000u64), &BigUint::from(1_050_000u64), &BigUint::from(1_000_000u64)),
+            BigUint::from(1_050_000u64)
+        );
+        assert_eq!(
+            map_staked_balance(&BigUint::from(1_000_000u64), &BigUint::from(0u8), &BigUint::from(1_000_000u64)),
+            BigUint::ZERO
+        );
+        assert_eq!(
+            map_staked_balance(&BigUint::from(1_000_000u64), &BigUint::from(1_050_000u64), &BigUint::ZERO),
+            BigUint::ZERO
+        );
+    }
+
+    #[test]
+    fn test_map_redeem_shares() {
+        assert_eq!(
+            map_redeem_shares(
+                &BigUint::from(1_050_000u64),
+                &BigUint::from(1_050_000u64),
+                &BigUint::from(1_000_000u64),
+                &BigUint::from(1_000_000u64)
+            ),
+            BigUint::from(1_000_000u64)
+        );
+        assert_eq!(
+            map_redeem_shares(
+                &BigUint::from(525_000u64),
+                &BigUint::from(1_050_000u64),
+                &BigUint::from(1_000_000u64),
+                &BigUint::from(1_000_000u64)
+            ),
+            BigUint::from(500_000u64)
+        );
+        assert_eq!(
+            map_redeem_shares(
+                &BigUint::from(1_050_000u64),
+                &BigUint::from(1_050_001u64),
+                &BigUint::from(1_000_000u64),
+                &BigUint::from(1_000_000u64)
+            ),
+            BigUint::from(1_000_000u64)
+        );
+    }
+}

--- a/crates/yielder/src/tonstakers/mod.rs
+++ b/crates/yielder/src/tonstakers/mod.rs
@@ -1,0 +1,4 @@
+mod mapper;
+mod provider;
+
+pub use provider::TonstakersProvider;

--- a/crates/yielder/src/tonstakers/provider.rs
+++ b/crates/yielder/src/tonstakers/provider.rs
@@ -1,0 +1,139 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::try_join;
+use num_bigint::BigUint;
+use primitives::{AssetBalance, AssetId, Chain, ContractCallData, DelegationBase, DelegationValidator, EarnType, YieldProvider};
+
+use gem_jsonrpc::alien::{RpcClient, RpcProvider};
+use gem_ton::{
+    Address as TonAddress,
+    models::JettonWallet,
+    rpc::client::TonClient,
+    tonstakers::{STAKING_CONTRACT, TS_TON_MASTER, build_stake_payload_base64, build_unstake_payload_base64, get_pool_full_data},
+};
+
+use crate::client_factory::create_chain_client;
+use crate::error::YielderError;
+use crate::provider::EarnProvider;
+
+use super::mapper::{map_redeem_shares, map_staked_balance, map_to_delegation};
+
+pub struct TonstakersProvider {
+    rpc_provider: Arc<dyn RpcProvider>,
+}
+
+impl TonstakersProvider {
+    pub fn new(rpc_provider: Arc<dyn RpcProvider>) -> Self {
+        Self { rpc_provider }
+    }
+
+    fn get_client(&self) -> Result<TonClient<RpcClient>, YielderError> {
+        Ok(TonClient::new(create_chain_client(self.rpc_provider.clone(), Chain::Ton)?))
+    }
+
+    fn parse_owner(address: &str) -> Result<TonAddress, YielderError> {
+        TonAddress::parse(address).map_err(|err| YielderError::invalid_input(err.to_string()))
+    }
+
+    fn find_tonstaker_wallet(wallets: Vec<JettonWallet>) -> Option<JettonWallet> {
+        wallets.into_iter().find(|wallet| wallet.jetton == TS_TON_MASTER)
+    }
+}
+
+#[async_trait]
+impl EarnProvider for TonstakersProvider {
+    fn get_provider(&self, asset_id: &AssetId) -> Option<DelegationValidator> {
+        (asset_id.chain == Chain::Ton && asset_id.is_native()).then(|| YieldProvider::Tonstakers.delegation_validator(Chain::Ton))
+    }
+
+    async fn get_position(&self, address: &str, _asset_id: &AssetId) -> Result<Option<DelegationBase>, YielderError> {
+        let client = self.get_client()?;
+        let owner = Self::parse_owner(address)?;
+        let jetton_wallets = client.get_jetton_wallets(owner.to_string()).await?;
+        let wallet = Self::find_tonstaker_wallet(jetton_wallets.jetton_wallets).filter(|wallet| !wallet.balance.eq(&BigUint::ZERO));
+
+        let Some(wallet) = wallet else {
+            return Ok(None);
+        };
+
+        let pool = get_pool_full_data(&client, STAKING_CONTRACT).await?;
+        let balance = map_staked_balance(&wallet.balance, &pool.total_balance, &pool.supply);
+
+        Ok(Some(map_to_delegation(balance, wallet.balance)))
+    }
+
+    async fn get_balance(&self, _chain: Chain, address: &str, _token_ids: &[String]) -> Result<Vec<AssetBalance>, YielderError> {
+        Ok(self
+            .get_position(address, &AssetId::from_chain(Chain::Ton))
+            .await?
+            .map(|delegation| AssetBalance::new_earn(delegation.asset_id, delegation.balance))
+            .into_iter()
+            .collect())
+    }
+
+    async fn get_data(&self, _asset_id: &AssetId, address: &str, value: &str, earn_type: &EarnType) -> Result<ContractCallData, YielderError> {
+        let owner = Self::parse_owner(address)?;
+        let amount = BigUint::parse_bytes(value.as_bytes(), 10).ok_or_else(|| YielderError::invalid_input("invalid TON amount"))?;
+
+        match earn_type {
+            EarnType::Deposit(_) => Ok(ContractCallData::new(STAKING_CONTRACT.to_string(), build_stake_payload_base64()?)),
+            EarnType::Withdraw(delegation) => {
+                let client = self.get_client()?;
+                let (jetton_wallets, pool) = try_join!(client.get_jetton_wallets(owner.to_string()), get_pool_full_data(&client, STAKING_CONTRACT))?;
+                let wallet = Self::find_tonstaker_wallet(jetton_wallets.jetton_wallets).ok_or_else(|| YielderError::invalid_input("missing Tonstakers jetton wallet"))?;
+                let redeem_shares = map_redeem_shares(&amount, &pool.total_balance, &pool.supply, &delegation.base.shares);
+
+                Ok(ContractCallData::new(wallet.address, build_unstake_payload_base64(&owner, &redeem_shares)?))
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "yield_integration_tests"))]
+mod integration_tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use primitives::{AssetId, Chain, DelegationState, YieldProvider};
+    use settings::testkit::get_test_settings;
+    use swapper::NativeProvider;
+
+    use super::TonstakersProvider;
+    use crate::error::YielderError;
+    use crate::provider::EarnProvider;
+
+    const TONSTAKERS_ADDRESS: &str = "0:DB7FF3D4D432C072778CCD68E351B2BF55CEE86A13F488EA6E1DBC48C037DA23";
+
+    #[tokio::test]
+    async fn test_tonstakers_get_balance_and_positions() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let settings = get_test_settings();
+        let rpc_provider = Arc::new(NativeProvider::new_with_endpoints(HashMap::from([(Chain::Ton, settings.chains.ton.url)])));
+        let asset_id = AssetId::from_chain(Chain::Ton);
+        let provider = TonstakersProvider::new(rpc_provider);
+
+        let balances = gem_client::retry(
+            || provider.get_balance(Chain::Ton, TONSTAKERS_ADDRESS, &[]),
+            3,
+            Some(|err: &YielderError| gem_client::default_should_retry(err)),
+        )
+        .await?;
+        println!("balances: {balances:#?}");
+        assert_eq!(balances.len(), 1);
+        assert_eq!(balances[0].asset_id, asset_id);
+
+        let position = gem_client::retry(
+            || provider.get_position(TONSTAKERS_ADDRESS, &asset_id),
+            3,
+            Some(|err: &YielderError| gem_client::default_should_retry(err)),
+        )
+        .await?
+        .unwrap();
+        println!("position: {position:#?}");
+        assert_eq!(position.asset_id, asset_id);
+        assert_eq!(position.validator_id, YieldProvider::Tonstakers.as_ref());
+        assert_eq!(position.state, DelegationState::Active);
+
+        Ok(())
+    }
+}

--- a/crates/yielder/src/tonstakers/provider.rs
+++ b/crates/yielder/src/tonstakers/provider.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -45,6 +46,10 @@ impl TonstakersProvider {
 impl EarnProvider for TonstakersProvider {
     fn get_provider(&self, asset_id: &AssetId) -> Option<DelegationValidator> {
         (asset_id.chain == Chain::Ton && asset_id.is_native()).then(|| YieldProvider::Tonstakers.delegation_validator(Chain::Ton))
+    }
+
+    fn underlying_assets() -> HashMap<AssetId, Vec<AssetId>> {
+        HashMap::from([(AssetId::from_chain(Chain::Ton), vec![AssetId::from_token(Chain::Ton, TS_TON_MASTER)])])
     }
 
     async fn get_position(&self, address: &str, _asset_id: &AssetId) -> Result<Option<DelegationBase>, YielderError> {

--- a/crates/yielder/src/yielder.rs
+++ b/crates/yielder/src/yielder.rs
@@ -7,6 +7,7 @@ use primitives::{AssetBalance, AssetId, Chain, ContractCallData, DelegationBase,
 
 use crate::error::YielderError;
 use crate::provider::EarnProvider;
+use crate::tonstakers::TonstakersProvider;
 use crate::yo::YoEarnProvider;
 
 pub struct Yielder {
@@ -15,7 +16,7 @@ pub struct Yielder {
 
 impl Yielder {
     pub fn new(rpc_provider: Arc<dyn RpcProvider>) -> Self {
-        Self::with_providers(vec![Arc::new(YoEarnProvider::new(rpc_provider))])
+        Self::with_providers(vec![Arc::new(YoEarnProvider::new(rpc_provider.clone())), Arc::new(TonstakersProvider::new(rpc_provider))])
     }
 
     pub fn with_providers(providers: Vec<Arc<dyn EarnProvider>>) -> Self {
@@ -26,24 +27,43 @@ impl Yielder {
         self.providers.iter().filter_map(|p| p.get_provider(asset_id)).collect()
     }
 
+    pub fn providers_for_assets(&self, asset_ids: &[AssetId]) -> Vec<&Arc<dyn EarnProvider>> {
+        self.providers
+            .iter()
+            .filter(|p| asset_ids.iter().any(|asset_id| p.get_provider(asset_id).is_some()))
+            .collect()
+    }
+
     pub async fn get_positions(&self, address: &str, asset_id: &AssetId) -> Vec<DelegationBase> {
-        let futures: Vec<_> = self.providers.iter().map(|p| p.get_position(address, asset_id)).collect();
+        let futures = self
+            .providers_for_assets(std::slice::from_ref(asset_id))
+            .into_iter()
+            .map(|p| p.get_position(address, asset_id));
         futures::future::join_all(futures).await.into_iter().filter_map(|r| r.ok().flatten()).collect()
     }
 
     pub async fn get_balance(&self, chain: Chain, address: &str, token_ids: &[String]) -> Vec<AssetBalance> {
-        let futures: Vec<_> = self.providers.iter().map(|p| p.get_balance(chain, address, token_ids)).collect();
+        let asset_ids = Self::balance_asset_ids(chain, token_ids);
+        let futures = self.providers_for_assets(&asset_ids).into_iter().map(|p| p.get_balance(chain, address, token_ids));
         let balances = futures::future::join_all(futures).await.into_iter().filter_map(|r| r.ok()).flatten().collect();
         Self::map_earn_balances(balances)
     }
 
     pub async fn get_data(&self, asset_id: &AssetId, address: &str, value: &str, earn_type: &EarnType) -> Result<ContractCallData, YielderError> {
-        self.providers
-            .iter()
+        self.providers_for_assets(std::slice::from_ref(asset_id))
+            .into_iter()
             .find(|p| p.get_provider(asset_id).is_some_and(|v| v.id == earn_type.provider_id()))
             .ok_or(YielderError::NotSupportedAsset)?
             .get_data(asset_id, address, value, earn_type)
             .await
+    }
+
+    fn balance_asset_ids(chain: Chain, token_ids: &[String]) -> Vec<AssetId> {
+        if token_ids.is_empty() {
+            vec![AssetId::from_chain(chain)]
+        } else {
+            token_ids.iter().map(|token_id| AssetId::from_token(chain, token_id)).collect()
+        }
     }
 
     fn map_earn_balances(balances: Vec<AssetBalance>) -> Vec<AssetBalance> {

--- a/crates/yielder/src/yo/mapper.rs
+++ b/crates/yielder/src/yo/mapper.rs
@@ -3,7 +3,7 @@ use gem_evm::jsonrpc::TransactionObject;
 use gem_evm::u256::u256_to_biguint;
 use num_bigint::BigUint;
 use primitives::swap::ApprovalData;
-use primitives::{AssetBalance, AssetId, Chain, ContractCallData, DelegationBase, DelegationState, DelegationValidator, StakeProviderType, YieldProvider};
+use primitives::{AssetBalance, AssetId, ContractCallData, DelegationBase, DelegationState};
 
 use super::assets::YoAsset;
 use super::client::PositionData;
@@ -39,18 +39,6 @@ pub fn map_to_contract_call_data(transaction: TransactionObject, approval: Optio
     }
 }
 
-pub fn map_to_earn_provider(chain: Chain, provider: YieldProvider) -> DelegationValidator {
-    DelegationValidator {
-        chain,
-        id: provider.as_ref().to_string(),
-        name: provider.name().to_string(),
-        is_active: true,
-        commission: 0.0,
-        apr: 0.0,
-        provider_type: StakeProviderType::Earn,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,17 +56,6 @@ mod tests {
         assert_eq!(result.delegation_id, format!("yo-{}", YO_USDC.asset_id()));
         assert_eq!(result.balance, BigUint::from(1_050_000u64));
         assert_eq!(result.shares, BigUint::from(1_000_000u64));
-    }
-
-    #[test]
-    fn test_map_to_earn_provider() {
-        let result = map_to_earn_provider(Chain::Base, YieldProvider::Yo);
-
-        assert_eq!(result.id, "yo");
-        assert_eq!(result.name, "Yo");
-        assert_eq!(result.chain, Chain::Base);
-        assert_eq!(result.apr, 0.0);
-        assert_eq!(result.provider_type, StakeProviderType::Earn);
     }
 
     #[test]

--- a/crates/yielder/src/yo/mod.rs
+++ b/crates/yielder/src/yo/mod.rs
@@ -4,7 +4,7 @@ mod contract;
 mod mapper;
 mod provider;
 
-use assets::{YoAsset, supported_assets};
+pub(crate) use assets::{YoAsset, supported_assets};
 pub use provider::YoEarnProvider;
 
 use alloy_primitives::{Address, address};

--- a/crates/yielder/src/yo/provider.rs
+++ b/crates/yielder/src/yo/provider.rs
@@ -13,7 +13,7 @@ use crate::error::YielderError;
 use crate::provider::EarnProvider;
 
 use super::client::YoGatewayClient;
-use super::mapper::{map_to_asset_balance, map_to_contract_call_data, map_to_delegation, map_to_earn_provider};
+use super::mapper::{map_to_asset_balance, map_to_contract_call_data, map_to_delegation};
 use super::{YO_GATEWAY, YO_PARTNER_ID_GEM, YoAsset, supported_assets};
 
 const GAS_LIMIT: u64 = 300_000;
@@ -59,7 +59,7 @@ impl YoEarnProvider {
 #[async_trait]
 impl EarnProvider for YoEarnProvider {
     fn get_provider(&self, asset_id: &AssetId) -> Option<DelegationValidator> {
-        self.get_asset(asset_id).ok().map(|a| map_to_earn_provider(a.chain, YieldProvider::Yo))
+        self.get_asset(asset_id).ok().map(|a| YieldProvider::Yo.delegation_validator(a.chain))
     }
 
     async fn get_position(&self, address: &str, asset_id: &AssetId) -> Result<Option<DelegationBase>, YielderError> {
@@ -97,7 +97,7 @@ impl EarnProvider for YoEarnProvider {
                 (approval, transaction)
             }
             EarnType::Withdraw(delegation) => {
-                let total_shares = biguint_to_u256(&delegation.base.shares).ok_or_else(|| YielderError::NetworkError("Invalid shares".to_string()))?;
+                let total_shares = biguint_to_u256(&delegation.base.shares).ok_or_else(|| YielderError::invalid_input("invalid shares"))?;
                 let computed_shares = client.get_quote_shares(asset.yo_token, amount).await?;
                 let redeem_shares = if total_shares > computed_shares && total_shares - computed_shares <= U256::from(1) {
                     total_shares

--- a/crates/yielder/src/yo/provider.rs
+++ b/crates/yielder/src/yo/provider.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::slice::from_ref;
 use std::sync::Arc;
 
@@ -60,6 +61,13 @@ impl YoEarnProvider {
 impl EarnProvider for YoEarnProvider {
     fn get_provider(&self, asset_id: &AssetId) -> Option<DelegationValidator> {
         self.get_asset(asset_id).ok().map(|a| YieldProvider::Yo.delegation_validator(a.chain))
+    }
+
+    fn underlying_assets() -> HashMap<AssetId, Vec<AssetId>> {
+        supported_assets()
+            .iter()
+            .map(|asset| (asset.asset_id(), vec![AssetId::from_token(asset.chain, &asset.yo_token.to_string())]))
+            .collect()
     }
 
     async fn get_position(&self, address: &str, asset_id: &AssetId) -> Result<Option<DelegationBase>, YielderError> {

--- a/gemstone/src/config/earn.rs
+++ b/gemstone/src/config/earn.rs
@@ -1,0 +1,8 @@
+use std::collections::HashMap;
+
+pub fn get_underlying_assets_by_provider(provider_id: &str) -> HashMap<String, Vec<String>> {
+    yielder::get_underlying_assets_by_provider(provider_id)
+        .into_iter()
+        .map(|(backed_asset, underlying_assets)| (backed_asset.to_string(), underlying_assets.into_iter().map(|asset| asset.to_string()).collect()))
+        .collect()
+}

--- a/gemstone/src/config/mod.rs
+++ b/gemstone/src/config/mod.rs
@@ -1,5 +1,6 @@
 pub mod chain;
 pub mod docs;
+pub mod earn;
 pub mod node;
 pub mod public;
 pub mod rewards;
@@ -19,6 +20,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use {
     docs::{DocsUrl, get_docs_url},
+    earn::get_underlying_assets_by_provider,
     public::{ASSETS_URL, PublicUrl, get_public_url},
     rewards::{RewardsUrl, get_rewards_url},
     social::{SocialUrl, get_social_url, get_social_url_deeplink},
@@ -45,6 +47,10 @@ impl Config {
     fn get_stake_config(&self, chain: &str) -> StakeChainConfig {
         let chain = StakeChain::from_str(chain).unwrap();
         get_stake_config(chain)
+    }
+
+    fn get_underlying_assets_by_provider(&self, provider_id: &str) -> HashMap<String, Vec<String>> {
+        get_underlying_assets_by_provider(provider_id)
     }
 
     fn get_swap_config(&self) -> SwapConfig {


### PR DESCRIPTION
Adds a Tonstakers staking provider on TON: pool data RPC (get_pool_full_data → PoolFullData), stake/unstake call-data builders, and Yielder integration for deposit/withdraw flows. Wires sign_earn into TonChainSigner with Tonstakers opcode/fee enforcement.