### PR TITLE
Add JobConfiguration struct and export

### DIFF
--- a/crates/primitives/src/job_configuration.rs
+++ b/crates/primitives/src/job_configuration.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+use typeshare::typeshare;
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[typeshare(swift = "Sendable")]
+#[serde(rename_all = "camelCase")]
+pub struct JobConfiguration {
+    pub initial_interval_ms: u32,
+    pub max_interval_ms: u32,
+    pub step_factor: f32,
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -112,6 +112,8 @@ pub mod time;
 pub use self::time::unix_timestamp;
 pub mod transaction_state;
 pub use self::transaction_state::TransactionState;
+pub mod job_configuration;
+pub use self::job_configuration::JobConfiguration;
 pub mod username_status;
 pub use self::username_status::UsernameStatus;
 pub mod recent_activity_type;


### PR DESCRIPTION
Introduce a new JobConfiguration type for job backoff/timing settings. The struct (crates/primitives/src/job_configuration.rs) derives Debug/Clone/Copy/PartialEq and implements Serialize/Deserialize, uses serde camelCase and typeshare(swift = "Sendable"). Update crates/primitives/src/lib.rs to expose the new module and re-export JobConfiguration.