### PR TITLE
chore: bump docker image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM lukemathwalker/cargo-chef:latest-rust-1.94.1-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.95.0-bookworm AS chef
 WORKDIR /app
 ENV CARGO_INCREMENTAL=0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,14 +102,14 @@ services:
       dynode_internal: {}
 
   redis:
-    image: redis:7.0-alpine
+    image: redis:8.6-alpine
     container_name: redis
     restart: always
     ports:
       - 6379:6379
 
   postgres:
-    image: postgres:latest
+    image: postgres:17
     container_name: postgres
     ports:
       - 5432:5432
@@ -131,7 +131,7 @@ services:
       RABBITMQ_DEFAULT_PASS: password
 
   meilisearch:
-    image: getmeili/meilisearch:v1.21.0
+    image: getmeili/meilisearch:v1.44.0
     container_name: meilisearch
     restart: always
     ports:


### PR DESCRIPTION
Bumps stale/risky image pins:

- `redis:7.0-alpine` → `redis:8.6-alpine` (7.0 is EOL)
- `postgres:latest` → `postgres:17` (pin to avoid surprise upgrades)
- `getmeili/meilisearch:v1.21.0` → `getmeili/meilisearch:v1.44.0`
- `cargo-chef:latest-rust-1.94.1-bookworm` → `latest-rust-1.95.0-bookworm`

⚠️ Meilisearch jumps 23 minor versions — take a dump of the `meilisearch` volume before pulling the new image in prod in case the index format changed.